### PR TITLE
Create pre-compiled header (PCH) for the engine

### DIFF
--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -86,11 +86,11 @@ jobs:
         run: |
           $VULKAN_SDK_PATH = (Get-ChildItem -Path "C:\VulkanSDK" -Directory | Sort-Object -Property LastWriteTime -Descending | Select-Object -First 1).FullName
           $env:PATH += ";$VULKAN_SDK_PATH\Bin"
-          cmake --build ${{env.BUILD_PATH}} --config ${{env.BUILD_TYPE}}
+          cmake --build ${{env.BUILD_PATH}} --config ${{env.BUILD_TYPE}} -j 4
           cmake --install build/ --config Release
 
       - name: Build for Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cmake --build ${{env.BUILD_PATH}} --config ${{env.BUILD_TYPE}}
+          cmake --build ${{env.BUILD_PATH}} --config ${{env.BUILD_TYPE}} -j 4
           cmake --install build/ --config Release

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -108,6 +108,10 @@ else()
     message(WARNING "[MELTDOWN] Unknown build type: \"${CMAKE_BUILD_TYPE}\"")
 endif()
 
+# Configures the pre-compiled headers
+set(MTD_PCH_DIR "pch")
+target_precompile_headers(${MELTDOWN_LIB} PRIVATE "${MTD_PCH_DIR}/pch.hpp")
+
 # Library interface include directory
 set(MTD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(MTD_INSTALL_INCLUDE_DIR "Engine/include")
@@ -115,7 +119,7 @@ set(MTD_INSTALL_INCLUDE_DIR "Engine/include")
 # Configures include directories and libraries
 target_include_directories(
     ${MELTDOWN_LIB}
-    PRIVATE ${MTD_INCLUDES}
+    PRIVATE ${MTD_INCLUDES} ${MTD_PCH_DIR}
     PUBLIC $<BUILD_INTERFACE:${MTD_INCLUDE_DIR}>
     PUBLIC $<INSTALL_INTERFACE:${MTD_INSTALL_INCLUDE_DIR}>
 )

--- a/Engine/pch/pch.hpp
+++ b/Engine/pch/pch.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <array>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <vulkan/vulkan.hpp>

--- a/Engine/src/Camera/Camera.cpp
+++ b/Engine/src/Camera/Camera.cpp
@@ -1,6 +1,5 @@
+#include <pch.hpp>
 #include "Camera.hpp"
-
-#include <glm/gtc/matrix_transform.hpp>
 
 #include "../Utils/Logger.hpp"
 #include "../Window/Window.hpp"

--- a/Engine/src/Engine.cpp
+++ b/Engine/src/Engine.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Engine.hpp"
 
 #include "Utils/Logger.hpp"

--- a/Engine/src/Input/InputHandler.cpp
+++ b/Engine/src/Input/InputHandler.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "InputHandler.hpp"
 
 #include "../Window/Window.hpp"

--- a/Engine/src/Math/Mat4x4.cpp
+++ b/Engine/src/Math/Mat4x4.cpp
@@ -1,8 +1,5 @@
+#include <pch.hpp>
 #include <meltdown/math.hpp>
-
-#include <iomanip>
-
-#include <glm/glm.hpp>
 
 mtd::Mat4x4::Mat4x4
 (

--- a/Engine/src/Math/Vec3.cpp
+++ b/Engine/src/Math/Vec3.cpp
@@ -1,6 +1,5 @@
+#include <pch.hpp>
 #include <meltdown/math.hpp>
-
-#include <iomanip>
 
 mtd::Vec3::Vec3(float x, float y, float z) : x{x}, y{y}, z{z}
 {

--- a/Engine/src/Math/Vec4.cpp
+++ b/Engine/src/Math/Vec4.cpp
@@ -1,7 +1,7 @@
+#include <pch.hpp>
 #include <meltdown/math.hpp>
 
 #include <cmath>
-#include <iomanip>
 
 mtd::Vec4::Vec4(float x, float y, float z, float w) : x{x}, y{y}, z{z}, w{w}
 {

--- a/Engine/src/Meltdown.cpp
+++ b/Engine/src/Meltdown.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include <Meltdown.hpp>
 
 #include "Engine.hpp"

--- a/Engine/src/Model/ModelHandler.cpp
+++ b/Engine/src/Model/ModelHandler.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include <meltdown/model.hpp>
 
 #include "EmptyModel.hpp"

--- a/Engine/src/Scene/Scene.cpp
+++ b/Engine/src/Scene/Scene.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Scene.hpp"
 
 #include "../Utils/Logger.hpp"

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "SceneLoader.hpp"
 
 #include <nlohmann/json.hpp>

--- a/Engine/src/Utils/FileHandler.cpp
+++ b/Engine/src/Utils/FileHandler.cpp
@@ -1,6 +1,5 @@
+#include <pch.hpp>
 #include "FileHandler.hpp"
-
-#include <fstream>
 
 #include "Logger.hpp"
 

--- a/Engine/src/Utils/Logger.cpp
+++ b/Engine/src/Utils/Logger.cpp
@@ -1,7 +1,7 @@
+#include <pch.hpp>
 #include "Logger.hpp"
 
 #include <cstdarg>
-#include <iostream>
 
 #define BUFFER_SIZE 1024
 

--- a/Engine/src/Utils/StringParser.cpp
+++ b/Engine/src/Utils/StringParser.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "StringParser.hpp"
 
 // Separates a line into substrings, using the specified delimiter

--- a/Engine/src/Vulkan/Command/CommandHandler.cpp
+++ b/Engine/src/Vulkan/Command/CommandHandler.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "CommandHandler.hpp"
 
 #include "../Gui/Gui.hpp"

--- a/Engine/src/Vulkan/Command/Synchronization.cpp
+++ b/Engine/src/Vulkan/Command/Synchronization.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Synchronization.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "DescriptorPool.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "DescriptorSetHandler.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Device/Device.cpp
+++ b/Engine/src/Vulkan/Device/Device.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Device.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Device/Memory.cpp
+++ b/Engine/src/Vulkan/Device/Memory.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Memory.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Device/PhysicalDevice.cpp
+++ b/Engine/src/Vulkan/Device/PhysicalDevice.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "PhysicalDevice.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Device/QueueFamilies.cpp
+++ b/Engine/src/Vulkan/Device/QueueFamilies.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "QueueFamilies.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Frame/Frame.cpp
+++ b/Engine/src/Vulkan/Frame/Frame.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Frame.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Frame/Swapchain.cpp
+++ b/Engine/src/Vulkan/Frame/Swapchain.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Swapchain.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Gui/Gui.cpp
+++ b/Engine/src/Vulkan/Gui/Gui.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Gui.hpp"
 
 #include <imgui_impl_glfw.h>

--- a/Engine/src/Vulkan/Gui/SettingsGui.cpp
+++ b/Engine/src/Vulkan/Gui/SettingsGui.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "SettingsGui.hpp"
 
 #include <imgui.h>

--- a/Engine/src/Vulkan/Image/Image.cpp
+++ b/Engine/src/Vulkan/Image/Image.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Image.hpp"
 
 #include "../Device/Memory.hpp"

--- a/Engine/src/Vulkan/Image/Texture.cpp
+++ b/Engine/src/Vulkan/Image/Texture.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Texture.hpp"
 
 #define STB_IMAGE_IMPLEMENTATION

--- a/Engine/src/Vulkan/Instance/DebugMessenger.cpp
+++ b/Engine/src/Vulkan/Instance/DebugMessenger.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "DebugMessenger.hpp"
 
 // The debug messenger is only compiled for debug builds

--- a/Engine/src/Vulkan/Instance/VulkanInstance.cpp
+++ b/Engine/src/Vulkan/Instance/VulkanInstance.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "VulkanInstance.hpp"
 
 #include "DebugMessenger.hpp"

--- a/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Billboard.hpp"
 
 mtd::Billboard::Billboard

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.cpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "BillboardManager.hpp"
 
 #include "../../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "DefaultMesh.hpp"
 
 #include "../ObjMeshLoader.hpp"

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "DefaultMeshManager.hpp"
 
 #include "../../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Mesh/Mesh.cpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Mesh.hpp"
 
 #include <cstring>

--- a/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
+++ b/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
@@ -1,9 +1,5 @@
+#include <pch.hpp>
 #include "ObjMeshLoader.hpp"
-
-#include <fstream>
-#include <unordered_map>
-
-#include <iostream>
 
 #include "../../Utils/FileHandler.hpp"
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Pipeline/Builders/ColorBlendBuilder.cpp
+++ b/Engine/src/Vulkan/Pipeline/Builders/ColorBlendBuilder.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "ColorBlendBuilder.hpp"
 
 #include "../../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Pipeline/Builders/ShaderLoader.cpp
+++ b/Engine/src/Vulkan/Pipeline/Builders/ShaderLoader.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "ShaderLoader.hpp"
 
 #include "../../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Pipeline/Builders/VertexInputBuilder.cpp
+++ b/Engine/src/Vulkan/Pipeline/Builders/VertexInputBuilder.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "VertexInputBuilder.hpp"
 
 #include "../../../Utils/EngineStructs.hpp"

--- a/Engine/src/Vulkan/Pipeline/Pipeline.cpp
+++ b/Engine/src/Vulkan/Pipeline/Pipeline.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Pipeline.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Vulkan/Pipeline/ShaderModule.cpp
+++ b/Engine/src/Vulkan/Pipeline/ShaderModule.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "ShaderModule.hpp"
 
 #include "../../Utils/FileHandler.hpp"

--- a/Engine/src/Vulkan/Render/Renderer.cpp
+++ b/Engine/src/Vulkan/Render/Renderer.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Renderer.hpp"
 
 #include "../../Utils/Logger.hpp"

--- a/Engine/src/Window/Window.cpp
+++ b/Engine/src/Window/Window.cpp
@@ -1,3 +1,4 @@
+#include <pch.hpp>
 #include "Window.hpp"
 
 #include <imgui_impl_glfw.h>


### PR DESCRIPTION
Gathering the most used headers in the project in a single header file allows it to be pre-compiled, reducing the compilation time.