### PR TITLE
Use ImGUI docking

### DIFF
--- a/.github/workflows/cmake-build.yaml
+++ b/.github/workflows/cmake-build.yaml
@@ -56,10 +56,17 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config
 
-      - name: Install vcpkg dependencies
+      - name: Install vcpkg dependencies for Windows
+        if: matrix.os == 'windows-latest'
         run: |
           vcpkg --version
-          vcpkg install glfw3 glm vulkan nlohmann-json imgui[core,glfw-binding,vulkan-binding] stb
+          vcpkg install glfw3 glm vulkan nlohmann-json stb imgui[docking-experimental,glfw-binding,vulkan-binding] --triplet=x64-windows-static
+
+      - name: Install vcpkg dependencies for Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+            vcpkg --version
+            vcpkg install glfw3 glm vulkan nlohmann-json stb imgui[docking-experimental,glfw-binding,vulkan-binding]
 
       - name: Configure CMake for Windows
         if: matrix.os == 'windows-latest'
@@ -67,9 +74,10 @@ jobs:
           cmake -S ${{github.workspace}}
           -B ${{env.BUILD_PATH}}
           -G "Visual Studio 17 2022"
-          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-          -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-          -DCMAKE_INSTALL_PREFIX="./install"
+          -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -D CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -D CMAKE_INSTALL_PREFIX="./install"
+          -D VCPKG_TARGET_TRIPLET=x64-windows-static
 
       - name: Configure CMake for Ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -77,8 +85,8 @@ jobs:
           cmake -S ${{github.workspace}}
           -B ${{env.BUILD_PATH}}
           -G "Ninja Multi-Config"
-          -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-          -DCMAKE_INSTALL_PREFIX="./install"
+          -D CMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -D CMAKE_INSTALL_PREFIX="./install"
 
       - name: Build for Windows
         if: matrix.os == 'windows-latest'

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -5,10 +5,14 @@ cmake_minimum_required(VERSION 3.26)
 project(Meltdown)
 
 # Meltdown Engine library name
-set(MELTDOWN_LIB meltdown)
+set(MELTDOWN_LIB "meltdown")
 # Library targets and configuration files
 set(MTD_TARGETS "meltdownTargets")
 set(MTD_CONFIG "meltdownConfig.cmake")
+
+# Colored tag for Meltdown logging
+string(ASCII 27 ESCAPE_CHAR)
+set(MTD_TAG "${ESCAPE_CHAR}[94m[MELTDOWN]${ESCAPE_CHAR}[0m")
 
 # Sets compilation with C++20
 set(CMAKE_CXX_STANDARD 20)
@@ -17,7 +21,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Defines build type if undefined
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
-    message(STATUS "[MELTDOWN] No build type specified. Using \"Debug\".")
+    message(STATUS "${MTD_TAG} No build type specified. Using \"Debug\".")
+endif()
+
+# Verifies if the packages will be linked statically on Windows
+if(WIN32 AND NOT VCPKG_TARGET_TRIPLET MATCHES "-windows-static$")
+    message(WARNING "${MTD_TAG} It is recommended to use the static triplet on Windows")
 endif()
 
 # Searches for required packages
@@ -74,22 +83,22 @@ add_custom_target(SHADERS DEPENDS ${SHADER_OUTPUTS})
 # Gathers source files (.cpp) to be compiled
 file(GLOB_RECURSE SRC_FILES "src/**.cpp")
 
-# Makes the engine a shared library if MTD_SHARED_LIBRARY is defined, otherwise, makes it a static library
+# Makes the engine a shared library if MTD_SHARED_LIBRARY is defined, or a static library otherwise
 if(MTD_SHARED_LIB)
     if(WIN32)
         set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-        message(STATUS "[MELTDOWN] Exporting all DLL symbols for Windows.")
+        message(STATUS "${MTD_TAG} Exporting all DLL symbols for Windows.")
     endif()
 
     add_library(${MELTDOWN_LIB} SHARED ${SRC_FILES})
 
     add_compile_definitions(${MELTDOWN_LIB} PUBLIC MTD_SHARED)
     add_compile_definitions(${MELTDOWN_LIB} PRIVATE MTD_EXPORTS)
-    message(STATUS "[MELTDOWN] Creating Meltdown Engine as a shared library...")
+    message(STATUS "${MTD_TAG} Creating Meltdown Engine as a shared library...")
 else()
     add_library(${MELTDOWN_LIB} STATIC ${SRC_FILES})
 
-    message(STATUS "[MELTDOWN] Creating Meltdown Engine as a static library...")
+    message(STATUS "${MTD_TAG} Creating Meltdown Engine as a static library...")
 endif()
 
 # The library depends on the shaders compilation
@@ -100,16 +109,16 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(${MELTDOWN_LIB} PRIVATE MTD_DEBUG=2)
     add_compile_definitions(${MELTDOWN_LIB} PRIVATE MTD_RESOURCES_PATH="${RESOURCES_DIR}/")
 
-    message(STATUS "[MELTDOWN] Building for debug...")
+    message(STATUS "${MTD_TAG} Building for debug...")
 elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     add_compile_definitions(${MELTDOWN_LIB} PRIVATE MTD_DEBUG=1)
     add_compile_definitions(${MELTDOWN_LIB} PRIVATE MTD_RESOURCES_PATH="${RESOURCES_DIR}/")
 
-    message(STATUS "[MELTDOWN] Building for release with debug info...")
+    message(STATUS "${MTD_TAG} Building for release with debug info...")
 elseif(CMAKE_BUILD_TYPE MATCHES "^(Release|MinSizeRel)$")
-    message(STATUS "[MELTDOWN] Building for release...")
+    message(STATUS "${MTD_TAG} Building for release...")
 else()
-    message(WARNING "[MELTDOWN] Unknown build type: \"${CMAKE_BUILD_TYPE}\"")
+    message(WARNING "${MTD_TAG} Unknown build type: \"${CMAKE_BUILD_TYPE}\"")
 endif()
 
 # Configures the pre-compiled headers
@@ -151,7 +160,6 @@ install(
 )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MTD_CONFIG}" DESTINATION "lib/cmake/meltdown")
 install(DIRECTORY ${RESOURCES_DIR} DESTINATION .)
-install(FILES $<TARGET_FILE:glfw> DESTINATION .)
 if(MTD_SHARED_LIB)
     install(FILES $<TARGET_FILE:${MELTDOWN_LIB}> DESTINATION .)
 endif()

--- a/Engine/src/GUIs/GuiWindow.cpp
+++ b/Engine/src/GUIs/GuiWindow.cpp
@@ -2,6 +2,6 @@
 #include "GuiWindow.hpp"
 
 mtd::GuiWindow::GuiWindow(ImVec2 winSize, ImVec2 winPos)
-	: showWindow{false}, windowSize{winSize}, windowPos{winPos}
+	: showWindow{true}, windowSize{winSize}, windowPos{winPos}
 {
 }

--- a/Engine/src/GUIs/ProfilerGui.cpp
+++ b/Engine/src/GUIs/ProfilerGui.cpp
@@ -12,6 +12,8 @@ mtd::ProfilerGui::ProfilerGui()
 
 void mtd::ProfilerGui::renderGui()
 {
+	if(!showWindow) return;
+
 	ImGui::SetNextWindowSize(windowSize, ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowPos(windowPos, ImGuiCond_FirstUseEver);
 	ImGui::Begin("Frame Profiler", &showWindow);

--- a/Engine/src/GUIs/SettingsGui.cpp
+++ b/Engine/src/GUIs/SettingsGui.cpp
@@ -21,6 +21,8 @@ void mtd::SettingsGui::setPipelinesSettings(std::unordered_map<PipelineType, Pip
 // Exhibits the GUI window
 void mtd::SettingsGui::renderGui()
 {
+	if(!showWindow) return;
+
 	ImGui::SetNextWindowSize(windowSize, ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowPos(windowPos, ImGuiCond_FirstUseEver);
 	ImGui::Begin("Engine Settings", &showWindow);

--- a/Engine/src/Vulkan/Frame/Swapchain.cpp
+++ b/Engine/src/Vulkan/Frame/Swapchain.cpp
@@ -41,7 +41,7 @@ void mtd::Swapchain::recreate
 // Enables or disables V-Sync
 bool mtd::Swapchain::setVSync(bool enableVSync)
 {
-	if(!enableVSync)
+	if(enableVSync)
 	{
 		if(settings.presentMode == vk::PresentModeKHR::eFifo) return false;
 

--- a/Engine/src/Vulkan/ImGui/ImGuiHandler.cpp
+++ b/Engine/src/Vulkan/ImGui/ImGuiHandler.cpp
@@ -15,6 +15,7 @@ mtd::ImGuiHandler::ImGuiHandler(const vk::Device& vulkanDevice)
 	ImGui::StyleColorsDark();
 
 	ImGuiIO& io = ImGui::GetIO();
+	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 	io.IniFilename = NULL;
 
 	createDescriptorPool();

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ Intended features for this project include:
 - Manipulate lightning;
 
 
-
 ## Install Guide
 
 Required tools to install and execute the **Meltdown Engine** in a development environment:
-- [CMake](https://cmake.org) (version 3.26 or higher), as well as a [generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html), to compile the code;
+- [CMake](https://cmake.org) (version 3.26 or higher), as well as a
+	[generator](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html), to compile the code;
 - [vcpkg](https://vcpkg.io) to download required libraries (optionally, the dependencies can be installed manually);
 - [Vulkan SDK](https://vulkan.lunarg.com) to use Vulkan features required by the engine;
 
-After downloading and installing the required tools, find the file `/scripts/buildsystems/vcpkg.cmake` at the **vcpkg** install location, and set the environment variable `CMAKE_TOOLCHAIN_FILE` to this file full path.
+After downloading and installing the required tools, find the file `/scripts/buildsystems/vcpkg.cmake`
+at the **vcpkg** install location, and set the environment variable `CMAKE_TOOLCHAIN_FILE` to this file full path.
 
+---
 
 Make sure **CMake**, **vcpkg** and the **Vulkan SDK** executables are accessible through the command line:
 
@@ -34,20 +36,39 @@ vcpkg --version
 glslc --version
 ```
 
-If not, add the executables to the PATH.
+If they are not accessible, try adding the executables to the **PATH**.
 
+---
 
 The required libraries can be installed by running the following command:
 
 ```bash
-vcpkg install glfw3 glm vulkan nlohmann-json imgui[core,glfw-binding,vulkan-binding]
+vcpkg install glfw3 glm vulkan nlohmann-json stb imgui[docking-experimental,glfw-binding,vulkan-binding]
 ```
 
+If on Windows, it is recommended to link the packages statically, to avoid missing DLL problems
+when running an application that uses the Meltdown Engine.
+This can be done by appending `--triplet=x64-windows-static` to the command above.
+
+---
 
 To build the project, run the command:
 
 ```bash
-cmake -S . -B build/ -G <generator_of_your_choice>
+cmake -S . -B build/ -G <Generator of your choice> -D CMAKE_BUILD_TYPE=<Build type>
 ```
 
-Use the chosen generator to compile the code and create the executable. This step will be different, depending on the generator used.
+Use the chosen generator to compile the code and create the executable.
+This step will be different, depending on the generator used.
+
+The build type can be `Debug`, `Release`, `RelWithDebInfo` or `MinSizeRel`. If not defined, the
+build type will be set to `Debug`.
+
+On Windows, if the `x64-windows-static` triplet has been used, it is also necessary to append
+`-D VCPKG_TARGET_TRIPLET=x64-windows-static` to the **cmake** command.
+
+
+## Recommendations
+
+Create scripts such as `build.sh`, `run.sh` and `clear.sh` (or `.cmd`/`.ps1` if on Windows) to
+build and run the Engine more easily.


### PR DESCRIPTION
The engine dependencies are now statically linked on Windows, by using the `64-windows-static` triplet.

The ImGUI package now uses the `docking-experimental` instead of `core` to use the docking features for the GUI.

Minor bugs have also been fixed.