### PR TITLE
Add dynamic model instancing

### DIFF
--- a/Engine/include/meltdown/enums.hpp
+++ b/Engine/include/meltdown/enums.hpp
@@ -16,6 +16,7 @@ namespace mtd
 		ActionStop,
 		WindowPosition,
 		ChangeScene,
+		ChangeInstanceCount,
 		Custom
 	};
 

--- a/Engine/include/meltdown/event.hpp
+++ b/Engine/include/meltdown/event.hpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 #include <meltdown/enums.hpp>
 
@@ -200,6 +201,41 @@ namespace mtd
 
 		private:
 			const char* sceneName;
+	};
+
+	/*
+	* @brief Event class for adding or removing instances of a specific mesh on dispatch.
+	*/
+	class ChangeInstanceCountEvent : public Event
+	{
+		public:
+			/*
+			* @brief Creates an event to add or remove instances for a certain mesh.
+			*
+			* @param modelID String identifying the target model.
+			* @param instanceCountVariation Quantity of instances to be added (positive value),
+			* or removed (negative value).
+			*/
+			ChangeInstanceCountEvent(const char* modelID, int32_t instanceCountVariation);
+
+			virtual EventType getType() const override;
+
+			/*
+			* @brief Getter for the target model ID.
+			*
+			* @return Identifier for the model which will have the mesh instance count altered.
+			*/
+			const std::string& getModelID() const;
+			/*
+			* @brief Getter for the variation of instance count.
+			*
+			* @return Amount of instances to be added or removed.
+			*/
+			int32_t getInstanceCountVariation() const;
+
+		private:
+			std::string modelID;
+			int32_t instanceCountVariation;
 	};
 
 	/*

--- a/Engine/src/Engine.cpp
+++ b/Engine/src/Engine.cpp
@@ -105,7 +105,7 @@ void mtd::Engine::run()
 // Loads a new scene, clearing the previous if necessary
 void mtd::Engine::loadScene(const char* sceneFile)
 {
-	scene.loadScene(sceneFile, commandHandler, pipelines);
+	scene.loadScene(device, sceneFile, commandHandler, pipelines);
 	configureDescriptors();
 
 	scene.start();

--- a/Engine/src/Engine.cpp
+++ b/Engine/src/Engine.cpp
@@ -105,7 +105,7 @@ void mtd::Engine::run()
 // Loads a new scene, clearing the previous if necessary
 void mtd::Engine::loadScene(const char* sceneFile)
 {
-	scene.loadScene(device, sceneFile, commandHandler, pipelines);
+	scene.loadScene(device, sceneFile, pipelines);
 	configureDescriptors();
 
 	scene.start();

--- a/Engine/src/Event/Event.cpp
+++ b/Engine/src/Event/Event.cpp
@@ -102,6 +102,29 @@ const char* mtd::ChangeSceneEvent::getSceneName() const
 	return sceneName;
 }
 
+// Change instance count event
+mtd::ChangeInstanceCountEvent::ChangeInstanceCountEvent
+(
+	const char* modelID, int32_t instanceCountVariation
+) : modelID{modelID}, instanceCountVariation{instanceCountVariation}
+{
+}
+
+mtd::EventType mtd::ChangeInstanceCountEvent::getType() const
+{
+	return EventType::ChangeInstanceCount;
+}
+
+const std::string& mtd::ChangeInstanceCountEvent::getModelID() const
+{
+	return modelID;
+}
+
+int32_t mtd::ChangeInstanceCountEvent::getInstanceCountVariation() const
+{
+	return instanceCountVariation;
+}
+
 // Custom event
 mtd::EventType mtd::CustomEvent::getType() const
 {

--- a/Engine/src/Scene/Scene.cpp
+++ b/Engine/src/Scene/Scene.cpp
@@ -12,6 +12,7 @@ mtd::Scene::Scene(const Device& device) : descriptorPool{device.getDevice()}
 // Loads scene from file
 void mtd::Scene::loadScene
 (
+	const Device& device,
 	const char* sceneFileName,
 	const CommandHandler& commandHandler,
 	std::unordered_map<PipelineType, Pipeline>& pipelines
@@ -20,7 +21,7 @@ void mtd::Scene::loadScene
 	for(auto& [type, pMeshManager]: meshManagers)
 		pMeshManager->clearMeshes();
 
-	SceneLoader::load(sceneFileName, meshManagers);
+	SceneLoader::load(device, sceneFileName, meshManagers);
 	loadMeshes(commandHandler, pipelines);
 }
 

--- a/Engine/src/Scene/Scene.cpp
+++ b/Engine/src/Scene/Scene.cpp
@@ -12,17 +12,14 @@ mtd::Scene::Scene(const Device& device) : descriptorPool{device.getDevice()}
 // Loads scene from file
 void mtd::Scene::loadScene
 (
-	const Device& device,
-	const char* sceneFileName,
-	const CommandHandler& commandHandler,
-	std::unordered_map<PipelineType, Pipeline>& pipelines
+	const Device& device, const char* sceneFileName, std::unordered_map<PipelineType, Pipeline>& pipelines
 )
 {
 	for(auto& [type, pMeshManager]: meshManagers)
 		pMeshManager->clearMeshes();
 
 	SceneLoader::load(device, sceneFileName, meshManagers);
-	loadMeshes(commandHandler, pipelines);
+	loadMeshes(pipelines);
 }
 
 // Executes starting code on scene
@@ -56,11 +53,7 @@ uint32_t mtd::Scene::getTotalTextureCount() const
 }
 
 // Allocate resources and loads all mesh data
-void mtd::Scene::loadMeshes
-(
-	const CommandHandler& commandHandler,
-	std::unordered_map<PipelineType, Pipeline>& pipelines
-)
+void mtd::Scene::loadMeshes(std::unordered_map<PipelineType, Pipeline>& pipelines)
 {
 	descriptorPool.clear();
 
@@ -79,7 +72,7 @@ void mtd::Scene::loadMeshes
 			descriptorSetHandler.defineDescriptorSetsAmount(pMeshManager->getMeshCount());
 			descriptorPool.allocateDescriptorSet(descriptorSetHandler);
 
-			pMeshManager->loadMeshes(commandHandler, descriptorSetHandler);
+			pMeshManager->loadMeshes(descriptorSetHandler);
 		}
 	}
 

--- a/Engine/src/Scene/Scene.hpp
+++ b/Engine/src/Scene/Scene.hpp
@@ -28,10 +28,7 @@ namespace mtd
 			// Loads scene from file
 			void loadScene
 			(
-				const Device& device,
-				const char* sceneFileName,
-				const CommandHandler& commandHandler,
-				std::unordered_map<PipelineType, Pipeline>& pipelines
+				const Device& device, const char* sceneFileName, std::unordered_map<PipelineType, Pipeline>& pipelines
 			);
 
 			// Executes starting code on scene
@@ -50,10 +47,6 @@ namespace mtd
 			uint32_t getTotalTextureCount() const;
 
 			// Allocate resources and loads all mesh data
-			void loadMeshes
-			(
-				const CommandHandler& commandHandler,
-				std::unordered_map<PipelineType, Pipeline>& pipelines
-			);
+			void loadMeshes(std::unordered_map<PipelineType, Pipeline>& pipelines);
 	};
 }

--- a/Engine/src/Scene/Scene.hpp
+++ b/Engine/src/Scene/Scene.hpp
@@ -28,6 +28,7 @@ namespace mtd
 			// Loads scene from file
 			void loadScene
 			(
+				const Device& device,
 				const char* sceneFileName,
 				const CommandHandler& commandHandler,
 				std::unordered_map<PipelineType, Pipeline>& pipelines

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -114,8 +114,7 @@ void getBillboard
 	std::string id = billboardJson.value("model-id", "");
 	std::vector<std::array<float, 16>> preTransforms = billboardJson["pre-transforms"];
 
-	std::vector<mtd::Billboard>& billboards =
-		dynamic_cast<mtd::BillboardManager*>(pMeshManager)->getBillboards();
+	std::vector<mtd::Billboard>& billboards = dynamic_cast<mtd::BillboardManager*>(pMeshManager)->getMeshes();
 	billboards.emplace_back
 	(
 		device,

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -70,35 +70,11 @@ void getDefaultMesh
 {
 	std::string file = meshJson["file"];
 	std::string id = meshJson.value("model-id", "");
-	std::vector<std::array<float, 16>> preTransforms = meshJson["pre-transforms"];
+	const std::vector<std::array<float, 16>>& preTransforms = meshJson["pre-transforms"];
+	const std::vector<mtd::Mat4x4>* pPreTransforms = reinterpret_cast<const std::vector<mtd::Mat4x4>*>(&preTransforms);
 
-	std::vector<mtd::DefaultMesh>& meshes =
-		dynamic_cast<mtd::DefaultMeshManager*>(pMeshManager)->getMeshes();
-	meshes.emplace_back
-	(
-		device,
-		index,
-		id.c_str(),
-		file.c_str(),
-		mtd::Mat4x4
-		{
-			preTransforms[0][0], preTransforms[0][1], preTransforms[0][2], preTransforms[0][3],
-			preTransforms[0][4], preTransforms[0][5], preTransforms[0][6], preTransforms[0][7],
-			preTransforms[0][8], preTransforms[0][9], preTransforms[0][10], preTransforms[0][11],
-			preTransforms[0][12], preTransforms[0][13], preTransforms[0][14], preTransforms[0][15]
-		}
-	);
-
-	for(uint32_t i = 1; i < preTransforms.size(); i++)
-	{
-		meshes.back().addInstance(mtd::Mat4x4
-		{
-			preTransforms[i][0], preTransforms[i][1], preTransforms[i][2], preTransforms[i][3],
-			preTransforms[i][4], preTransforms[i][5], preTransforms[i][6], preTransforms[i][7],
-			preTransforms[i][8], preTransforms[i][9], preTransforms[i][10], preTransforms[i][11],
-			preTransforms[i][12], preTransforms[i][13], preTransforms[i][14], preTransforms[i][15]
-		});
-	}
+	std::vector<mtd::DefaultMesh>& meshes = dynamic_cast<mtd::DefaultMeshManager*>(pMeshManager)->getMeshes();
+	meshes.emplace_back(device, index, id.c_str(), file.c_str(), *pPreTransforms);
 }
 
 // Fetches billboards from scene file
@@ -112,32 +88,9 @@ void getBillboard
 {
 	std::string texturePath = billboardJson["texture"];
 	std::string id = billboardJson.value("model-id", "");
-	std::vector<std::array<float, 16>> preTransforms = billboardJson["pre-transforms"];
+	const std::vector<std::array<float, 16>>& preTransforms = billboardJson["pre-transforms"];
+	const std::vector<mtd::Mat4x4>* pPreTransforms = reinterpret_cast<const std::vector<mtd::Mat4x4>*>(&preTransforms);
 
 	std::vector<mtd::Billboard>& billboards = dynamic_cast<mtd::BillboardManager*>(pMeshManager)->getMeshes();
-	billboards.emplace_back
-	(
-		device,
-		index,
-		id.c_str(),
-		texturePath.c_str(),
-		mtd::Mat4x4
-		{
-			preTransforms[0][0], preTransforms[0][1], preTransforms[0][2], preTransforms[0][3],
-			preTransforms[0][4], preTransforms[0][5], preTransforms[0][6], preTransforms[0][7],
-			preTransforms[0][8], preTransforms[0][9], preTransforms[0][10], preTransforms[0][11],
-			preTransforms[0][12], preTransforms[0][13], preTransforms[0][14], preTransforms[0][15]
-		}
-	);
-
-	for(uint32_t i = 1; i < preTransforms.size(); i++)
-	{
-		billboards.back().addInstance(mtd::Mat4x4
-		{
-			preTransforms[i][0], preTransforms[i][1], preTransforms[i][2], preTransforms[i][3],
-			preTransforms[i][4], preTransforms[i][5], preTransforms[i][6], preTransforms[i][7],
-			preTransforms[i][8], preTransforms[i][9], preTransforms[i][10], preTransforms[i][11],
-			preTransforms[i][12], preTransforms[i][13], preTransforms[i][14], preTransforms[i][15]
-		});
-	}
+	billboards.emplace_back(device, index, id.c_str(), texturePath.c_str(), *pPreTransforms);
 }

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -12,16 +12,23 @@
 
 static void getDefaultMesh
 (
-	const nlohmann::json& meshJson, uint32_t index, mtd::MeshManager* pMeshManager
+	const mtd::Device& device,
+	const nlohmann::json& meshJson,
+	uint32_t index,
+	mtd::MeshManager* pMeshManager
 );
 static void getBillboard
 (
-	const nlohmann::json& billboardJson, uint32_t index, mtd::MeshManager* pMeshManager
+	const mtd::Device& device,
+	const nlohmann::json& billboardJson,
+	uint32_t index,
+	mtd::MeshManager* pMeshManager
 );
 
 // Loads the meshes from a Meltdown scene file
 void mtd::SceneLoader::load
 (
+	const Device& device,
 	const char* fileName,
 	std::unordered_map<PipelineType, std::unique_ptr<MeshManager>>& meshManagers
 )
@@ -45,15 +52,21 @@ void mtd::SceneLoader::load
 	}
 
 	for(uint32_t i = 0; i < sceneJson["default-meshes"].size(); i++)
-		getDefaultMesh(sceneJson["default-meshes"][i], i, meshManagers.at(PipelineType::DEFAULT).get());
+		getDefaultMesh(device, sceneJson["default-meshes"][i], i, meshManagers.at(PipelineType::DEFAULT).get());
 	for(uint32_t i = 0; i < sceneJson["billboards"].size(); i++)
-		getBillboard(sceneJson["billboards"][i], i, meshManagers.at(PipelineType::BILLBOARD).get());
+		getBillboard(device, sceneJson["billboards"][i], i, meshManagers.at(PipelineType::BILLBOARD).get());
 
 	LOG_INFO("Scene \"%s\" loaded.", fileName);
 }
 
 // Fetches default meshes from scene file
-void getDefaultMesh(const nlohmann::json& meshJson, uint32_t index, mtd::MeshManager* pMeshManager)
+void getDefaultMesh
+(
+	const mtd::Device& device,
+	const nlohmann::json& meshJson,
+	uint32_t index,
+	mtd::MeshManager* pMeshManager
+)
 {
 	std::string file = meshJson["file"];
 	std::string id = meshJson.value("model-id", "");
@@ -63,6 +76,7 @@ void getDefaultMesh(const nlohmann::json& meshJson, uint32_t index, mtd::MeshMan
 		dynamic_cast<mtd::DefaultMeshManager*>(pMeshManager)->getMeshes();
 	meshes.emplace_back
 	(
+		device,
 		index,
 		id.c_str(),
 		file.c_str(),
@@ -88,7 +102,13 @@ void getDefaultMesh(const nlohmann::json& meshJson, uint32_t index, mtd::MeshMan
 }
 
 // Fetches billboards from scene file
-void getBillboard(const nlohmann::json& billboardJson, uint32_t index, mtd::MeshManager* pMeshManager)
+void getBillboard
+(
+	const mtd::Device& device,
+	const nlohmann::json& billboardJson,
+	uint32_t index,
+	mtd::MeshManager* pMeshManager
+)
 {
 	std::string texturePath = billboardJson["texture"];
 	std::string id = billboardJson.value("model-id", "");
@@ -98,6 +118,7 @@ void getBillboard(const nlohmann::json& billboardJson, uint32_t index, mtd::Mesh
 		dynamic_cast<mtd::BillboardManager*>(pMeshManager)->getBillboards();
 	billboards.emplace_back
 	(
+		device,
 		index,
 		id.c_str(),
 		texturePath.c_str(),

--- a/Engine/src/Scene/SceneLoader.hpp
+++ b/Engine/src/Scene/SceneLoader.hpp
@@ -10,6 +10,7 @@ namespace mtd::SceneLoader
 	// Loads the meshes from a Meltdown scene file
 	void load
 	(
+		const Device& device,
 		const char* fileName,
 		std::unordered_map<PipelineType, std::unique_ptr<MeshManager>>& meshManagers
 	);

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
@@ -52,14 +52,12 @@ void* mtd::DescriptorSetHandler::createDescriptorResources
 )
 {
 	DescriptorResources& resources = resourcesList[setIndex][resourceIndex];
-	Memory::createBuffer
-	(
-		mtdDevice,
-		resources.descriptorBuffer,
-		resourceSize,
-		usageFlags,
-		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent
-	);
+	resources.descriptorBuffer.size = resourceSize;
+	resources.descriptorBuffer.usage = usageFlags;
+	resources.descriptorBuffer.memoryProperties =
+		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
+
+	Memory::createBuffer(mtdDevice, resources.descriptorBuffer);
 	resources.descriptorBufferWriteLocation = device.mapMemory
 	(
 		resources.descriptorBuffer.bufferMemory, 0UL, resourceSize

--- a/Engine/src/Vulkan/Device/Memory.cpp
+++ b/Engine/src/Vulkan/Device/Memory.cpp
@@ -50,10 +50,7 @@ void mtd::Memory::allocateBufferMemory(const Device& device, Buffer& buffer)
 // Copies data to buffer mapped memory
 void mtd::Memory::copyMemory
 (
-	const vk::Device& device,
-	const vk::DeviceMemory& bufferMemory,
-	vk::DeviceSize size,
-	const void* srcData
+	const vk::Device& device, const vk::DeviceMemory& bufferMemory, vk::DeviceSize size, const void* srcData
 )
 {
 	void* memoryLocation = device.mapMemory(bufferMemory, 0, size);
@@ -79,7 +76,10 @@ void mtd::Memory::copyBuffer(Buffer& srcBuffer, Buffer& dstBuffer, const Command
 }
 
 // Changes the buffer size by reallocating it
-void mtd::Memory::resizeBuffer(const Device& device, Buffer& buffer, vk::DeviceSize newSize)
+void mtd::Memory::resizeBuffer
+(
+	const Device& device, const CommandHandler& commandHandler, Buffer& buffer, vk::DeviceSize newSize
+)
 {
 	Buffer newBuffer;
 	newBuffer.size = newSize;
@@ -87,7 +87,6 @@ void mtd::Memory::resizeBuffer(const Device& device, Buffer& buffer, vk::DeviceS
 	newBuffer.memoryProperties = buffer.memoryProperties;
 
 	createBuffer(device, newBuffer);
-	CommandHandler commandHandler{device};
 	copyBuffer(buffer, newBuffer, commandHandler);
 
 	device.getDevice().destroyBuffer(buffer.buffer);

--- a/Engine/src/Vulkan/Device/Memory.cpp
+++ b/Engine/src/Vulkan/Device/Memory.cpp
@@ -4,19 +4,12 @@
 #include "../../Utils/Logger.hpp"
 
 // Creates and allocates a buffer
-void mtd::Memory::createBuffer
-(
-	const Device& device,
-	Buffer& buffer,
-	vk::DeviceSize bufferSize,
-	vk::BufferUsageFlags bufferUsage,
-	vk::MemoryPropertyFlags memoryProperties
-)
+void mtd::Memory::createBuffer(const Device& device, Buffer& buffer)
 {
 	vk::BufferCreateInfo bufferCreateInfo{};
 	bufferCreateInfo.flags = vk::BufferCreateFlags();
-	bufferCreateInfo.size = bufferSize;
-	bufferCreateInfo.usage = bufferUsage;
+	bufferCreateInfo.size = buffer.size;
+	bufferCreateInfo.usage = buffer.usage;
 	bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
 	bufferCreateInfo.queueFamilyIndexCount = 0;
 	bufferCreateInfo.pQueueFamilyIndices = nullptr;
@@ -29,16 +22,11 @@ void mtd::Memory::createBuffer
 		return;
 	}
 
-	allocateBufferMemory(device, buffer, memoryProperties);
+	allocateBufferMemory(device, buffer);
 }
 
 // Allocates memory for the buffer
-void mtd::Memory::allocateBufferMemory
-(
-	const Device& device,
-	Buffer& buffer,
-	vk::MemoryPropertyFlags memoryProperties
-)
+void mtd::Memory::allocateBufferMemory(const Device& device, Buffer& buffer)
 {
 	const vk::Device& vulkanDevice = device.getDevice();
 	vk::MemoryRequirements memoryRequirements =
@@ -48,7 +36,7 @@ void mtd::Memory::allocateBufferMemory
 	memoryAllocateInfo.allocationSize = memoryRequirements.size;
 	memoryAllocateInfo.memoryTypeIndex = findMemoryTypeIndex
 	(
-		device.getPhysicalDevice(), memoryRequirements.memoryTypeBits, memoryProperties
+		device.getPhysicalDevice(), memoryRequirements.memoryTypeBits, buffer.memoryProperties
 	);
 
 	vk::Result result =
@@ -77,20 +65,16 @@ void mtd::Memory::copyMemory
 }
 
 // Copies one buffer to another
-void mtd::Memory::copyBuffer
-(
-	Buffer& srcBuffer,
-	Buffer& dstBuffer,
-	vk::DeviceSize size,
-	const CommandHandler& commandHandler
-)
+void mtd::Memory::copyBuffer(Buffer& srcBuffer, Buffer& dstBuffer, const CommandHandler& commandHandler)
 {
+	vk::DeviceSize copySize = (dstBuffer.size > srcBuffer.size) ? srcBuffer.size : dstBuffer.size;
+
 	vk::CommandBuffer commandBuffer = commandHandler.beginSingleTimeCommand();
 
 	vk::BufferCopy bufferCopy{};
 	bufferCopy.srcOffset = 0;
 	bufferCopy.dstOffset = 0;
-	bufferCopy.size = size;
+	bufferCopy.size = copySize;
 
 	commandBuffer.copyBuffer(srcBuffer.buffer, dstBuffer.buffer, 1, &bufferCopy);
 

--- a/Engine/src/Vulkan/Device/Memory.hpp
+++ b/Engine/src/Vulkan/Device/Memory.hpp
@@ -33,6 +33,9 @@ namespace mtd::Memory
 	// Copies one buffer to another
 	void copyBuffer(Buffer& srcBuffer, Buffer& dstBuffer, const CommandHandler& commandHandler);
 
+	// Changes the buffer size by reallocating it
+	void resizeBuffer(const Device& device, Buffer& buffer, vk::DeviceSize newSize);
+
 	// Finds the memory type index that fits the requirements
 	uint32_t findMemoryTypeIndex
 	(

--- a/Engine/src/Vulkan/Device/Memory.hpp
+++ b/Engine/src/Vulkan/Device/Memory.hpp
@@ -24,17 +24,17 @@ namespace mtd::Memory
 	// Copies data to buffer mapped memory
 	void copyMemory
 	(
-		const vk::Device& device,
-		const vk::DeviceMemory& bufferMemory,
-		vk::DeviceSize size,
-		const void* srcData
+		const vk::Device& device, const vk::DeviceMemory& bufferMemory, vk::DeviceSize size, const void* srcData
 	);
 
 	// Copies one buffer to another
 	void copyBuffer(Buffer& srcBuffer, Buffer& dstBuffer, const CommandHandler& commandHandler);
 
 	// Changes the buffer size by reallocating it
-	void resizeBuffer(const Device& device, Buffer& buffer, vk::DeviceSize newSize);
+	void resizeBuffer
+	(
+		const Device& device, const CommandHandler& commandHandler, Buffer& buffer, vk::DeviceSize newSize
+	);
 
 	// Finds the memory type index that fits the requirements
 	uint32_t findMemoryTypeIndex
@@ -48,10 +48,7 @@ namespace mtd::Memory
 	template<typename T>
 	void createDeviceLocalBuffer
 	(
-		const Device& device,
-		Buffer& buffer,
-		const std::vector<T>& data,
-		const CommandHandler& commandHandler
+		const Device& device, Buffer& buffer, const std::vector<T>& data, const CommandHandler& commandHandler
 	)
 	{
 		Buffer stagingBuffer;

--- a/Engine/src/Vulkan/Image/Texture.cpp
+++ b/Engine/src/Vulkan/Image/Texture.cpp
@@ -79,16 +79,13 @@ void mtd::Texture::loadFromFile
 void mtd::Texture::loadToGpu(const Device& mtdDevice, const CommandHandler& commandHandler) const
 {
 	Memory::Buffer stagingBuffer;
-	vk::DeviceSize imageSize = width * height * 4;
-	Memory::createBuffer
-	(
-		mtdDevice,
-		stagingBuffer,
-		imageSize,
-		vk::BufferUsageFlagBits::eTransferSrc,
-		vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostVisible
-	);
-	Memory::copyMemory(device, stagingBuffer.bufferMemory, imageSize, pixels);
+	stagingBuffer.size = static_cast<vk::DeviceSize>(width * height * 4);
+	stagingBuffer.usage = vk::BufferUsageFlagBits::eTransferSrc;
+	stagingBuffer.memoryProperties =
+		vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostVisible;
+	Memory::createBuffer(mtdDevice, stagingBuffer);
+
+	Memory::copyMemory(device, stagingBuffer.bufferMemory, stagingBuffer.size, pixels);
 	Image::transitionImageLayout
 	(
 		image, commandHandler, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal

--- a/Engine/src/Vulkan/Mesh/BaseMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/BaseMeshManager.hpp
@@ -24,10 +24,10 @@ namespace mtd
 					int32_t instanceVariation = pEvent->getInstanceCountVariation();
 
 					if(instanceVariation < 0)
-						mesh.removeLastInstances(static_cast<uint32_t>(-instanceVariation));
+						mesh.removeLastInstances(commandHandler, static_cast<uint32_t>(-instanceVariation));
 					else
 					{
-						mesh.addInstances(instanceVariation);
+						mesh.addInstances(commandHandler, instanceVariation);
 						mesh.startLastAddedInstances(instanceVariation);
 					}
 				});

--- a/Engine/src/Vulkan/Mesh/BaseMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/BaseMeshManager.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <meltdown/event.hpp>
+
+#include "MeshManager.hpp"
+
+namespace mtd
+{
+	// Base class for the mesh managers, which implements generic mesh handling
+	template <typename MeshType = Mesh>
+	class BaseMeshManager : public MeshManager
+	{
+		static_assert(std::is_base_of<Mesh, MeshType>::value, "The MeshType must be derived from the Mesh class.");
+
+		public:
+			BaseMeshManager(const Device& device) : MeshManager{device}
+			{
+				EventManager::addCallback(EventType::ChangeInstanceCount, [this](const Event& e)
+				{
+					const ChangeInstanceCountEvent* pEvent = dynamic_cast<const ChangeInstanceCountEvent*>(&e);
+					if(meshIndexMap.find(pEvent->getModelID()) == meshIndexMap.end()) return;
+
+					MeshType& mesh = meshes[meshIndexMap.at(pEvent->getModelID())];
+					int32_t instanceVariation = pEvent->getInstanceCountVariation();
+
+					if(instanceVariation < 0)
+						mesh.removeLastInstances(static_cast<uint32_t>(-instanceVariation));
+					else
+					{
+						mesh.addInstances(instanceVariation);
+						mesh.startLastAddedInstances(instanceVariation);
+					}
+				});
+			}
+
+			// Getters
+			virtual uint32_t getMeshCount() const override
+				{ return static_cast<uint32_t>(meshes.size()); }
+			std::vector<MeshType>& getMeshes() { return meshes; }
+
+			// Executes the start code for each mesh on scene loading
+			virtual void start() override
+			{
+				for(MeshType& mesh: meshes)
+					mesh.start();
+			}
+
+			// Updates mesh data
+			virtual void update(double frameTime) override
+			{
+				for(MeshType& mesh: meshes)
+					mesh.update(frameTime);
+			}
+
+		protected:
+			// List of meshes
+			std::vector<MeshType> meshes;
+
+			// Map to translate a model ID to a mesh index
+			std::unordered_map<std::string, uint32_t> meshIndexMap;
+	};
+}

--- a/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
@@ -7,8 +7,8 @@ mtd::Billboard::Billboard
 	uint32_t index,
 	const char* id,
 	const char* texturePath,
-	const Mat4x4& preTransform
-) : Mesh{device, index, id, preTransform, 0}, texturePath{texturePath}
+	const std::vector<Mat4x4>& preTransforms
+) : Mesh{device, index, id, preTransforms, 0}, texturePath{texturePath}
 {
 }
 

--- a/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/Billboard.cpp
@@ -3,33 +3,27 @@
 
 mtd::Billboard::Billboard
 (
-	uint32_t index, const char* id, const char* texturePath, const Mat4x4& preTransform
-) : Mesh{index, id, preTransform}, texturePath{texturePath}
+	const Device& device,
+	uint32_t index,
+	const char* id,
+	const char* texturePath,
+	const Mat4x4& preTransform
+) : Mesh{device, index, id, preTransform, 0}, texturePath{texturePath}
 {
 }
 
 mtd::Billboard::Billboard(Billboard&& other) noexcept
-	: Mesh
-	{
-		other.meshIndex,
-		other.modelID,
-		std::move(other.models),
-		other.instanceLumpOffset,
-		other.pInstanceLump
-	},
+	: Mesh{std::move(other)},
 	texturePath{other.texturePath},
 	texture{std::move(other.texture)}
 {
 	other.texture = nullptr;
-	other.pInstanceLump = nullptr;
 }
 
 // Loads the billboard texture
 void mtd::Billboard::loadTexture
 (
-	const Device& device,
-	const CommandHandler& commandHandler,
-	DescriptorSetHandler& descriptorSetHandler
+	const CommandHandler& commandHandler, DescriptorSetHandler& descriptorSetHandler
 )
 {
 	texture = std::make_unique<Texture>

--- a/Engine/src/Vulkan/Mesh/Billboard/Billboard.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/Billboard.hpp
@@ -17,7 +17,7 @@ namespace mtd
 				uint32_t index,
 				const char* id,
 				const char* texturePath,
-				const Mat4x4& preTransform = Mat4x4{1.0f}
+				const std::vector<Mat4x4>& preTransforms
 			);
 			~Billboard() = default;
 

--- a/Engine/src/Vulkan/Mesh/Billboard/Billboard.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/Billboard.hpp
@@ -13,6 +13,7 @@ namespace mtd
 		public:
 			Billboard
 			(
+				const Device& device,
 				uint32_t index,
 				const char* id,
 				const char* texturePath,
@@ -28,9 +29,7 @@ namespace mtd
 			// Loads the billboard texture
 			void loadTexture
 			(
-				const Device& device,
-				const CommandHandler& commandHandler,
-				DescriptorSetHandler& descriptorSetHandler
+				const CommandHandler& commandHandler, DescriptorSetHandler& descriptorSetHandler
 			);
 
 		private:

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.cpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.cpp
@@ -13,10 +13,7 @@ mtd::BillboardManager::~BillboardManager()
 }
 
 // Loads the billboards textures to the GPU
-void mtd::BillboardManager::loadMeshes
-(
-	const CommandHandler& commandHandler, DescriptorSetHandler& textureDescriptorSetHandler
-)
+void mtd::BillboardManager::loadMeshes(DescriptorSetHandler& textureDescriptorSetHandler)
 {
 	for(uint32_t i = 0; i < meshes.size(); i++)
 	{
@@ -45,10 +42,7 @@ void mtd::BillboardManager::bindBuffers(const vk::CommandBuffer& commandBuffer) 
 }
 
 // Draws the mesh specified by the index
-void mtd::BillboardManager::drawMesh
-(
-	const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
-) const
+void mtd::BillboardManager::drawMesh(const vk::CommandBuffer& commandBuffer, uint32_t meshIndex) const
 {
 	const Billboard& billboard = meshes[meshIndex];
 	billboard.bindInstanceBuffer(commandBuffer);

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
@@ -38,26 +38,20 @@ namespace mtd
 			// Updates instances data
 			virtual void update(double frameTime) override;
 
-			// Binds the vertex buffer for instances data
+			// There is no buffer common to all billboards to be binded
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
 			// Draws the mesh specified by the index
 			virtual void drawMesh
 			(
-				const vk::CommandBuffer& commandBuffer, uint32_t index
+				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
 			) const override;
 
 		private:
-			// Transformation matrices for each instance
-			Memory::Buffer instanceBuffer;
-
 			// List of billboards
 			std::vector<Billboard> billboards;
 			// Textures for each billboard
 			std::vector<std::string> texturePaths;
 			std::vector<std::unique_ptr<Texture>> textures;
-
-			// Instances transforms lump
-			std::vector<Mat4x4> instanceLump;
 
 			// Device reference
 			const Device& device;

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
@@ -49,6 +49,9 @@ namespace mtd
 		private:
 			// List of billboards
 			std::vector<Billboard> billboards;
+			// Map to translate a model ID to a mesh index
+			std::unordered_map<std::string, uint32_t> billboardIndexMap;
+
 			// Textures for each billboard
 			std::vector<std::string> texturePaths;
 			std::vector<std::unique_ptr<Texture>> textures;

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
@@ -3,25 +3,17 @@
 #include <memory>
 
 #include "Billboard.hpp"
-#include "../MeshManager.hpp"
+#include "../BaseMeshManager.hpp"
 #include "../../Image/Texture.hpp"
 
 namespace mtd
 {
 	// Handles data from all billboards
-	class BillboardManager : public MeshManager
+	class BillboardManager : public BaseMeshManager<Billboard>
 	{
 		public:
 			BillboardManager(const Device& device);
 			~BillboardManager();
-
-			BillboardManager(const BillboardManager&) = delete;
-			BillboardManager& operator=(const BillboardManager&) = delete;
-
-			// Getters
-			virtual uint32_t getMeshCount() const override
-				{ return static_cast<uint32_t>(billboards.size()); }
-			std::vector<Billboard>& getBillboards() { return billboards; }
 
 			// Loads the billboards textures to the GPU
 			virtual void loadMeshes
@@ -33,11 +25,6 @@ namespace mtd
 			// Clears the list of billboards and the instance buffer
 			virtual void clearMeshes() override;
 
-			// Executes the start code for each model on scene loading
-			virtual void start() override;
-			// Updates instances data
-			virtual void update(double frameTime) override;
-
 			// There is no buffer common to all billboards to be binded
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
 			// Draws the mesh specified by the index
@@ -47,16 +34,8 @@ namespace mtd
 			) const override;
 
 		private:
-			// List of billboards
-			std::vector<Billboard> billboards;
-			// Map to translate a model ID to a mesh index
-			std::unordered_map<std::string, uint32_t> billboardIndexMap;
-
 			// Textures for each billboard
 			std::vector<std::string> texturePaths;
 			std::vector<std::unique_ptr<Texture>> textures;
-
-			// Device reference
-			const Device& device;
 	};
 }

--- a/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
+++ b/Engine/src/Vulkan/Mesh/Billboard/BillboardManager.hpp
@@ -16,11 +16,7 @@ namespace mtd
 			~BillboardManager();
 
 			// Loads the billboards textures to the GPU
-			virtual void loadMeshes
-			(
-				const CommandHandler& commandHandler,
-				DescriptorSetHandler& textureDescriptorSetHandler
-			) override;
+			virtual void loadMeshes(DescriptorSetHandler& textureDescriptorSetHandler) override;
 
 			// Clears the list of billboards and the instance buffer
 			virtual void clearMeshes() override;
@@ -28,10 +24,7 @@ namespace mtd
 			// There is no buffer common to all billboards to be binded
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
 			// Draws the mesh specified by the index
-			virtual void drawMesh
-			(
-				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
-			) const override;
+			virtual void drawMesh(const vk::CommandBuffer& commandBuffer, uint32_t meshIndex) const override;
 
 		private:
 			// Textures for each billboard

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
@@ -5,21 +5,18 @@
 
 mtd::DefaultMesh::DefaultMesh
 (
-	uint32_t index, const char* id, const char* fileName, const Mat4x4& preTransform
-) : Mesh{index, id, preTransform}, indexOffset{0}
+	const Device& device,
+	uint32_t index,
+	const char* id,
+	const char* fileName,
+	const Mat4x4& preTransform
+) : Mesh{device, index, id, preTransform, 1}, indexOffset{0}
 {
 	ObjMeshLoader::load(fileName, vertices, indices, diffuseTexturePath);
 }
 
 mtd::DefaultMesh::DefaultMesh(DefaultMesh&& other) noexcept
-	: Mesh
-	{
-		other.meshIndex,
-		other.modelID,
-		std::move(other.models),
-		other.instanceLumpOffset,
-		other.pInstanceLump
-	},
+	: Mesh{std::move(other)},
 	vertices{std::move(other.vertices)},
 	indices{std::move(other.indices)},
 	diffuseTexturePath{std::move(other.diffuseTexturePath)},
@@ -27,7 +24,6 @@ mtd::DefaultMesh::DefaultMesh(DefaultMesh&& other) noexcept
 	indexOffset{other.indexOffset}
 {
 	other.diffuseTexture = nullptr;
-	other.pInstanceLump = nullptr;
 }
 
 // Loads mesh texture

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.cpp
@@ -9,8 +9,8 @@ mtd::DefaultMesh::DefaultMesh
 	uint32_t index,
 	const char* id,
 	const char* fileName,
-	const Mat4x4& preTransform
-) : Mesh{device, index, id, preTransform, 1}, indexOffset{0}
+	const std::vector<Mat4x4>& preTransforms
+) : Mesh{device, index, id, preTransforms, 1}, indexOffset{0}
 {
 	ObjMeshLoader::load(fileName, vertices, indices, diffuseTexturePath);
 }

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.hpp
@@ -12,6 +12,7 @@ namespace mtd
 		public:
 			DefaultMesh
 			(
+				const Device& device,
 				uint32_t index,
 				const char* id,
 				const char* fileName,

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMesh.hpp
@@ -16,7 +16,7 @@ namespace mtd
 				uint32_t index,
 				const char* id,
 				const char* fileName,
-				const Mat4x4& preTransform = Mat4x4{1.0f}
+				const std::vector<Mat4x4>& preTransforms
 			);
 			~DefaultMesh() = default;
 

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
@@ -109,15 +109,11 @@ void mtd::DefaultMeshManager::loadMeshToLump(DefaultMesh& mesh)
 // Loads the lumps into the VRAM and clears them
 void mtd::DefaultMeshManager::loadMeshesToGPU(const CommandHandler& commandHandler)
 {
-	Memory::createDeviceLocalBuffer<Vertex>
-	(
-		device, vertexBuffer, vertexLump, vk::BufferUsageFlagBits::eVertexBuffer, commandHandler
-	);
+	vertexBuffer.usage = vk::BufferUsageFlagBits::eVertexBuffer;
+	indexBuffer.usage = vk::BufferUsageFlagBits::eIndexBuffer;
 
-	Memory::createDeviceLocalBuffer<uint32_t>
-	(
-		device, indexBuffer, indexLump, vk::BufferUsageFlagBits::eIndexBuffer, commandHandler
-	);
+	Memory::createDeviceLocalBuffer<Vertex>(device, vertexBuffer, vertexLump, commandHandler);
+	Memory::createDeviceLocalBuffer<uint32_t>(device, indexBuffer, indexLump, commandHandler);
 
 	for(DefaultMesh& defaultMesh: meshes)
 		defaultMesh.createInstanceBuffer();

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
@@ -1,29 +1,11 @@
 #include <pch.hpp>
 #include "DefaultMeshManager.hpp"
 
-#include <meltdown/event.hpp>
-
 #include "../../../Utils/Logger.hpp"
 
 mtd::DefaultMeshManager::DefaultMeshManager(const Device& device)
-	: device{device}, currentIndexOffset{0}, totalInstanceCount{0}
+	: BaseMeshManager{device}, currentIndexOffset{0}, totalInstanceCount{0}
 {
-	EventManager::addCallback(EventType::ChangeInstanceCount, [this](const Event& e)
-	{
-		const ChangeInstanceCountEvent* pEvent = dynamic_cast<const ChangeInstanceCountEvent*>(&e);
-		if(meshIndexMap.find(pEvent->getModelID()) == meshIndexMap.end()) return;
-
-		DefaultMesh& mesh = meshes[meshIndexMap.at(pEvent->getModelID())];
-		int32_t instanceVariation = pEvent->getInstanceCountVariation();
-
-		if(instanceVariation < 0)
-			mesh.removeLastInstances(static_cast<uint32_t>(-instanceVariation));
-		else
-		{
-			mesh.addInstances(instanceVariation);
-			mesh.startLastAddedInstances(instanceVariation);
-		}
-	});
 }
 
 mtd::DefaultMeshManager::~DefaultMeshManager()
@@ -63,20 +45,6 @@ void mtd::DefaultMeshManager::clearMeshes()
 
 	vulkanDevice.destroyBuffer(indexBuffer.buffer);
 	vulkanDevice.freeMemory(indexBuffer.bufferMemory);
-}
-
-// Executes the start code for each model on scene loading
-void mtd::DefaultMeshManager::start()
-{
-	for(DefaultMesh& mesh: meshes)
-		mesh.start();
-}
-
-// Updates instances data
-void mtd::DefaultMeshManager::update(double frameTime)
-{
-	for(DefaultMesh& mesh: meshes)
-		mesh.update(frameTime);
 }
 
 // Binds vertex and index buffers

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.cpp
@@ -14,11 +14,7 @@ mtd::DefaultMeshManager::~DefaultMeshManager()
 }
 
 // Loads textures and groups the meshes into a lump, then passes the data to the GPU
-void mtd::DefaultMeshManager::loadMeshes
-(
-	const CommandHandler& commandHandler,
-	DescriptorSetHandler& textureDescriptorSetHandler
-)
+void mtd::DefaultMeshManager::loadMeshes(DescriptorSetHandler& textureDescriptorSetHandler)
 {
 	for(uint32_t i = 0; i < meshes.size(); i++)
 	{
@@ -59,10 +55,7 @@ void mtd::DefaultMeshManager::bindBuffers
 }
 
 // Draws the mesh specified by the index
-void mtd::DefaultMeshManager::drawMesh
-(
-	const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
-) const
+void mtd::DefaultMeshManager::drawMesh(const vk::CommandBuffer& commandBuffer, uint32_t meshIndex) const
 {
 	const DefaultMesh& mesh = meshes[meshIndex];
 	mesh.bindInstanceBuffer(commandBuffer);

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
@@ -1,25 +1,19 @@
 #pragma once
 
 #include "DefaultMesh.hpp"
-#include "../MeshManager.hpp"
+#include "../BaseMeshManager.hpp"
 
 namespace mtd
 {
 	// Handles data from all default meshes
-	class DefaultMeshManager : public MeshManager
+	class DefaultMeshManager : public BaseMeshManager<DefaultMesh>
 	{
 		public:
 			DefaultMeshManager(const Device& device);
 			~DefaultMeshManager();
 
-			DefaultMeshManager(const DefaultMeshManager&) = delete;
-			DefaultMeshManager& operator=(const DefaultMeshManager&) = delete;
-
 			// Getters
-			virtual uint32_t getMeshCount() const override
-				{ return static_cast<uint32_t>(meshes.size()); }
 			uint32_t getTotalInstanceCount() const { return totalInstanceCount; }
-			std::vector<DefaultMesh>& getMeshes() { return meshes; }
 
 			// Loads textures and groups the meshes into a lump, then passes the data to the GPU
 			virtual void loadMeshes
@@ -30,11 +24,6 @@ namespace mtd
 
 			// Clears the list of default meshes and related buffers
 			virtual void clearMeshes() override;
-
-			// Executes the start code for each model on scene loading
-			virtual void start() override;
-			// Updates instances data
-			virtual void update(double frameTime) override;
 
 			// Binds vertex and index buffers
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
@@ -49,11 +38,6 @@ namespace mtd
 			Memory::Buffer vertexBuffer;
 			Memory::Buffer indexBuffer;
 
-			// Default meshes
-			std::vector<DefaultMesh> meshes;
-			// Map to translate a model ID to a mesh index
-			std::unordered_map<std::string, uint32_t> meshIndexMap;
-
 			// Lumps of data containing all vertices and indices from all meshes
 			std::vector<Vertex> vertexLump;
 			std::vector<uint32_t> indexLump;
@@ -62,9 +46,6 @@ namespace mtd
 			uint32_t totalInstanceCount;
 			// Index offset counter
 			uint32_t currentIndexOffset;
-
-			// Device reference
-			const Device& device;
 
 			// Stores a mesh in the lump of data
 			void loadMeshToLump(DefaultMesh& mesh);

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
@@ -16,11 +16,7 @@ namespace mtd
 			uint32_t getTotalInstanceCount() const { return totalInstanceCount; }
 
 			// Loads textures and groups the meshes into a lump, then passes the data to the GPU
-			virtual void loadMeshes
-			(
-				const CommandHandler& commandHandler,
-				DescriptorSetHandler& textureDescriptorSetHandler
-			) override;
+			virtual void loadMeshes(DescriptorSetHandler& textureDescriptorSetHandler) override;
 
 			// Clears the list of default meshes and related buffers
 			virtual void clearMeshes() override;
@@ -28,10 +24,7 @@ namespace mtd
 			// Binds vertex and index buffers
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
 			// Draws the mesh specified by the index
-			virtual void drawMesh
-			(
-				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
-			) const override;
+			virtual void drawMesh(const vk::CommandBuffer& commandBuffer, uint32_t meshIndex) const override;
 
 		private:
 			// Vertex and index data of all meshes in the VRAM

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
@@ -2,7 +2,6 @@
 
 #include "DefaultMesh.hpp"
 #include "../MeshManager.hpp"
-#include "../../Device/Memory.hpp"
 
 namespace mtd
 {
@@ -42,15 +41,13 @@ namespace mtd
 			// Draws the mesh specified by the index
 			virtual void drawMesh
 			(
-				const vk::CommandBuffer& commandBuffer, uint32_t index
+				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
 			) const override;
 
 		private:
 			// Vertex and index data of all meshes in the VRAM
 			Memory::Buffer vertexBuffer;
 			Memory::Buffer indexBuffer;
-			// Transformation matrices for each instance
-			Memory::Buffer instanceBuffer;
 
 			// Default meshes
 			std::vector<DefaultMesh> meshes;
@@ -58,7 +55,6 @@ namespace mtd
 			// Lumps of data containing all vertices and indices from all meshes
 			std::vector<Vertex> vertexLump;
 			std::vector<uint32_t> indexLump;
-			std::vector<Mat4x4> instanceLump;
 
 			// Total number of instances
 			uint32_t totalInstanceCount;

--- a/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/DefaultMesh/DefaultMeshManager.hpp
@@ -51,6 +51,8 @@ namespace mtd
 
 			// Default meshes
 			std::vector<DefaultMesh> meshes;
+			// Map to translate a model ID to a mesh index
+			std::unordered_map<std::string, uint32_t> meshIndexMap;
 
 			// Lumps of data containing all vertices and indices from all meshes
 			std::vector<Vertex> vertexLump;

--- a/Engine/src/Vulkan/Mesh/Mesh.cpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.cpp
@@ -102,7 +102,7 @@ void mtd::Mesh::startLastAddedInstances(uint32_t instanceCount)
 }
 
 // Adds multiple new mesh instances with the identity pre-transform matrix
-void mtd::Mesh::addInstances(uint32_t instanceCount)
+void mtd::Mesh::addInstances(const CommandHandler& commandHandler, uint32_t instanceCount)
 {
 	uint32_t minimumBufferSize = (models.size() + instanceCount) * sizeof(Mat4x4);
 	if(minimumBufferSize > instanceBuffer.size)
@@ -111,7 +111,7 @@ void mtd::Mesh::addInstances(uint32_t instanceCount)
 		while(newSize < minimumBufferSize)
 			newSize += newSize;
 
-		Memory::resizeBuffer(device, instanceBuffer, newSize);
+		Memory::resizeBuffer(device, commandHandler, instanceBuffer, newSize);
 	}
 
 	for(uint32_t i = 0; i < instanceCount; i++)
@@ -122,7 +122,7 @@ void mtd::Mesh::addInstances(uint32_t instanceCount)
 }
 
 // Removes the last mesh instances
-void mtd::Mesh::removeLastInstances(uint32_t instanceCount)
+void mtd::Mesh::removeLastInstances(const CommandHandler& commandHandler, uint32_t instanceCount)
 {
 	if(models.size() <= 0) return;
 	if(models.size() < instanceCount)
@@ -140,7 +140,7 @@ void mtd::Mesh::removeLastInstances(uint32_t instanceCount)
 		while(newBufferSizeMaxLimit <= newSize)
 			newSize >>= 1;
 
-		Memory::resizeBuffer(device, instanceBuffer, newSize);
+		Memory::resizeBuffer(device, commandHandler, instanceBuffer, newSize);
 	}
 }
 

--- a/Engine/src/Vulkan/Mesh/Mesh.cpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.cpp
@@ -8,17 +8,19 @@ mtd::Mesh::Mesh
 	const Device& device,
 	uint32_t index,
 	const char* modelID,
-	const Mat4x4& preTransform,
+	const std::vector<Mat4x4>& preTransforms,
 	uint32_t instanceBufferBindIndex
 ) : device{device},
 	meshIndex{index},
 	modelID{modelID},
 	modelFactory{ModelHandler::getModelFactory(modelID)},
 	models{},
+	instanceLump{preTransforms},
 	instanceBufferBindIndex{instanceBufferBindIndex}
 {
-	models.emplace_back(modelFactory(preTransform));
-	instanceLump.emplace_back(preTransform);
+
+	for(const Mat4x4& preTransform: preTransforms)
+		models.emplace_back(modelFactory(preTransform));
 }
 
 mtd::Mesh::~Mesh()
@@ -97,16 +99,6 @@ void mtd::Mesh::startLastAddedInstances(uint32_t instanceCount)
 		models[i]->start();
 		std::memcpy(&(instanceLump[i]), models[i]->getTransformPointer(), sizeof(Mat4x4));
 	}
-}
-
-// Adds a new mesh instance with a pre-transform matrix
-void mtd::Mesh::addInstance(const Mat4x4& preTransform)
-{
-	if((models.size() + 1) * sizeof(Mat4x4) > instanceBuffer.size)
-		Memory::resizeBuffer(device, instanceBuffer, 2 * instanceBuffer.size);
-
-	models.emplace_back(modelFactory(preTransform));
-	instanceLump.emplace_back(preTransform);
 }
 
 // Adds multiple new mesh instances with the identity pre-transform matrix

--- a/Engine/src/Vulkan/Mesh/Mesh.cpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.cpp
@@ -99,18 +99,15 @@ void mtd::Mesh::addInstance(const Mat4x4& preTransform)
 // Creates a GPU buffer for the transformation matrices
 void mtd::Mesh::createInstanceBuffer()
 {
-	vk::DeviceSize instanceLumpSize = instanceLump.size() * sizeof(Mat4x4);
-	Memory::createBuffer
-	(
-		device,
-		instanceBuffer,
-		instanceLumpSize,
-		vk::BufferUsageFlagBits::eVertexBuffer,
-		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent
-	);
+	instanceBuffer.size = instanceLump.size() * sizeof(Mat4x4);
+	instanceBuffer.usage = vk::BufferUsageFlagBits::eVertexBuffer;
+	instanceBuffer.memoryProperties =
+		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
+
+	Memory::createBuffer(device, instanceBuffer);
 	Memory::copyMemory
 	(
-		device.getDevice(), instanceBuffer.bufferMemory, instanceLumpSize, instanceLump.data()
+		device.getDevice(), instanceBuffer.bufferMemory, instanceBuffer.size, instanceLump.data()
 	);
 }
 

--- a/Engine/src/Vulkan/Mesh/Mesh.hpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.hpp
@@ -41,9 +41,9 @@ namespace mtd
 			void startLastAddedInstances(uint32_t instanceCount);
 
 			// Adds multiple new mesh instances with the identity pre-transform matrix
-			void addInstances(uint32_t instanceCount);
+			void addInstances(const CommandHandler& commandHandler, uint32_t instanceCount);
 			// Removes the last mesh instances
-			void removeLastInstances(uint32_t instanceCount);
+			void removeLastInstances(const CommandHandler& commandHandler, uint32_t instanceCount);
 
 			// Creates a GPU buffer for the transformation matrices
 			void createInstanceBuffer();

--- a/Engine/src/Vulkan/Mesh/Mesh.hpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.hpp
@@ -5,39 +5,45 @@
 
 #include <meltdown/model.hpp>
 
+#include "../Device/Memory.hpp"
+
 namespace mtd
 {
-	// Generic mesh data
+	// Base class for handling meshes in Vulkan
 	class Mesh
 	{
 		public:
-			Mesh(uint32_t index, const char* modelID, const Mat4x4& preTransform);
 			Mesh
 			(
+				const Device& device,
 				uint32_t index,
-				const std::string& modelID,
-				std::vector<std::unique_ptr<Model>>&& models,
-				size_t instanceLumpOffset,
-				std::vector<Mat4x4>* pInstanceLump
+				const char* modelID,
+				const Mat4x4& preTransform,
+				uint32_t instanceBufferBindIndex = 0
 			);
-			virtual ~Mesh() = default;
+			virtual ~Mesh();
 
 			Mesh(const Mesh&) = delete;
 			Mesh& operator=(const Mesh&) = delete;
 
+			Mesh(Mesh&& other) noexcept;
+
 			// Getters
 			uint32_t getInstanceCount() const { return static_cast<uint32_t>(models.size()); }
-			uint32_t getInstanceOffset() const { return static_cast<uint32_t>(instanceLumpOffset); }
 
 			// Runs once at the beginning of the scene for all instances
 			void start();
 			// Updates all instances
 			void update(double deltaTime);
 
-			// Sets a reference to the instance lump to update the instances data
-			void setInstancesLump(std::vector<Mat4x4>* instanceLumpPointer, size_t offset);
 			// Adds a new instance
 			void addInstance(const Mat4x4& preTransform = Mat4x4{1.0f});
+
+			// Creates a GPU buffer for the transformation matrices
+			void createInstanceBuffer();
+
+			// Binds the instance buffer for this mesh
+			void bindInstanceBuffer(const vk::CommandBuffer& commandBuffer) const;
 
 		protected:
 			// Mesh index
@@ -50,8 +56,14 @@ namespace mtd
 			// Model data for each instance of the mesh
 			std::vector<std::unique_ptr<Model>> models;
 
-			// Pointer to the instance lump vector and start index
-			size_t instanceLumpOffset;
-			std::vector<Mat4x4>* pInstanceLump;
+			// Transformation matrices for each mesh instance
+			std::vector<Mat4x4> instanceLump;
+			// GPU buffer for the transformation matrices
+			Memory::Buffer instanceBuffer;
+			// Binding index for the instance buffer
+			uint32_t instanceBufferBindIndex;
+
+			// Device reference
+			const Device& device;
 	};
 }

--- a/Engine/src/Vulkan/Mesh/Mesh.hpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.hpp
@@ -30,14 +30,22 @@ namespace mtd
 
 			// Getters
 			uint32_t getInstanceCount() const { return static_cast<uint32_t>(models.size()); }
+			const char* getModelID() const { return modelID.c_str(); }
 
 			// Runs once at the beginning of the scene for all instances
 			void start();
 			// Updates all instances
 			void update(double deltaTime);
 
-			// Adds a new instance
+			// Starts the last instances added
+			void startLastAddedInstances(uint32_t instanceCount);
+
+			// Adds a new mesh instance with a pre-transform matrix
 			void addInstance(const Mat4x4& preTransform = Mat4x4{1.0f});
+			// Adds multiple new mesh instances with the identity pre-transform matrix
+			void addInstances(uint32_t instanceCount);
+			// Removes the last mesh instances
+			void removeLastInstances(uint32_t instanceCount);
 
 			// Creates a GPU buffer for the transformation matrices
 			void createInstanceBuffer();

--- a/Engine/src/Vulkan/Mesh/Mesh.hpp
+++ b/Engine/src/Vulkan/Mesh/Mesh.hpp
@@ -18,7 +18,7 @@ namespace mtd
 				const Device& device,
 				uint32_t index,
 				const char* modelID,
-				const Mat4x4& preTransform,
+				const std::vector<Mat4x4>& preTransforms,
 				uint32_t instanceBufferBindIndex = 0
 			);
 			virtual ~Mesh();
@@ -40,8 +40,6 @@ namespace mtd
 			// Starts the last instances added
 			void startLastAddedInstances(uint32_t instanceCount);
 
-			// Adds a new mesh instance with a pre-transform matrix
-			void addInstance(const Mat4x4& preTransform = Mat4x4{1.0f});
 			// Adds multiple new mesh instances with the identity pre-transform matrix
 			void addInstances(uint32_t instanceCount);
 			// Removes the last mesh instances

--- a/Engine/src/Vulkan/Mesh/MeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/MeshManager.cpp
@@ -1,0 +1,7 @@
+#include <pch.hpp>
+#include "MeshManager.hpp"
+
+mtd::MeshManager::MeshManager(const Device& device)
+	: device{device}
+{
+}

--- a/Engine/src/Vulkan/Mesh/MeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/MeshManager.cpp
@@ -2,6 +2,6 @@
 #include "MeshManager.hpp"
 
 mtd::MeshManager::MeshManager(const Device& device)
-	: device{device}
+	: device{device}, commandHandler{device}
 {
 }

--- a/Engine/src/Vulkan/Mesh/MeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/MeshManager.hpp
@@ -1,14 +1,21 @@
 #pragma once
 
+#include <type_traits>
+
+#include "Mesh.hpp"
 #include "../Descriptors/DescriptorSetHandler.hpp"
 
 namespace mtd
 {
-	// Interface for different mesh managers
+	// Interface for the mesh managers
 	class MeshManager
 	{
 		public:
+			MeshManager(const Device& device);
 			virtual ~MeshManager() = default;
+
+			MeshManager(const MeshManager&) = delete;
+			MeshManager& operator=(const MeshManager&) = delete;
 
 			// Gets the number of different meshes handled by the manager
 			virtual uint32_t getMeshCount() const = 0;
@@ -33,7 +40,11 @@ namespace mtd
 			// Draws the mesh specified by the index
 			virtual void drawMesh
 			(
-				const vk::CommandBuffer& commandBuffer, uint32_t index
+				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
 			) const = 0;
+
+		protected:
+			// Device reference
+			const Device& device;
 	};
 }

--- a/Engine/src/Vulkan/Mesh/MeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/MeshManager.hpp
@@ -21,11 +21,7 @@ namespace mtd
 			virtual uint32_t getMeshCount() const = 0;
 
 			// Loads mesh data to the GPU
-			virtual void loadMeshes
-			(
-				const CommandHandler& commandHandler,
-				DescriptorSetHandler& textureDescriptorSetHandler
-			) = 0;
+			virtual void loadMeshes(DescriptorSetHandler& textureDescriptorSetHandler) = 0;
 
 			// Clears mesh data
 			virtual void clearMeshes() = 0;
@@ -38,13 +34,12 @@ namespace mtd
 			// Binds vertex and index buffers, if used
 			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const = 0;
 			// Draws the mesh specified by the index
-			virtual void drawMesh
-			(
-				const vk::CommandBuffer& commandBuffer, uint32_t meshIndex
-			) const = 0;
+			virtual void drawMesh(const vk::CommandBuffer& commandBuffer, uint32_t meshIndex) const = 0;
 
 		protected:
 			// Device reference
 			const Device& device;
+			// Mesh manager command handler
+			CommandHandler commandHandler;
 	};
 }


### PR DESCRIPTION
With dynamic model instancing, it is possible to create new mesh instances at any time, instead of being limited to the scene loading time.