### PR TITLE
Overhaul event system

### DIFF
--- a/Application/src/CameraController.cpp
+++ b/Application/src/CameraController.cpp
@@ -15,12 +15,6 @@ CameraController::CameraController()
 	registerCallbacks();
 }
 
-CameraController::~CameraController()
-{
-	mtd::EventManager::removeCallback(mtd::EventType::ActionStart, actionStartCallbackID);
-	mtd::EventManager::removeCallback(mtd::EventType::ActionStop, actionStopCallbackID);
-}
-
 // Updates the camera data every frame
 void CameraController::update(double deltaTime)
 {
@@ -44,12 +38,9 @@ void CameraController::update(double deltaTime)
 // Registers action event callbacks for camera input
 void CameraController::registerCallbacks()
 {
-	actionStartCallbackID = mtd::EventManager::addCallback(mtd::EventType::ActionStart, [this](const mtd::Event& e)
+	actionStartCallbackHandle = mtd::EventManager::addCallback([this](const mtd::ActionStartEvent& event)
 	{
-		const mtd::ActionStartEvent* actionStart = dynamic_cast<const mtd::ActionStartEvent*>(&e);
-		if(!actionStart) return;
-
-		switch(actionStart->getAction())
+		switch(event.getAction())
 		{
 			case Actions::Forward:
 				inputVelocity.z += 1.0f;
@@ -83,12 +74,9 @@ void CameraController::registerCallbacks()
 		}
 	});
 
-	actionStopCallbackID = mtd::EventManager::addCallback(mtd::EventType::ActionStop, [this](const mtd::Event& e)
+	actionStopCallbackHandle = mtd::EventManager::addCallback([this](const mtd::ActionStopEvent& event)
 	{
-		const mtd::ActionStopEvent* actionStop = dynamic_cast<const mtd::ActionStopEvent*>(&e);
-		if(!actionStop) return;
-
-		switch(actionStop->getAction())
+		switch(event.getAction())
 		{
 			case Actions::Forward:
 				inputVelocity.z -= 1.0f;
@@ -122,12 +110,9 @@ void CameraController::registerCallbacks()
 		}
 	});
 
-	mtd::EventManager::addCallback(mtd::EventType::MousePosition, [this](const mtd::Event& e)
+	mousePositionCallbackHandle = mtd::EventManager::addCallback([this](const mtd::MousePositionEvent& event)
 	{
-		const mtd::MousePositionEvent* mousePosition = dynamic_cast<const mtd::MousePositionEvent*>(&e);
-		if(!mousePosition) return;
-
-		if(mousePosition->isCursorHidden())
-			lastCursorPos = mousePosition->getMousePosition();
+		if(event.isCursorHidden())
+			lastCursorPos = event.getMousePosition();
 	});
 }

--- a/Application/src/CameraController.hpp
+++ b/Application/src/CameraController.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <Meltdown.hpp>
+#include <meltdown/event.hpp>
 
 // Handles the camera behavior for the application
 class CameraController
 {
 	public:
 		CameraController();
-		~CameraController();
+		~CameraController() = default;
 
 		CameraController(const CameraController&) = delete;
 		CameraController& operator=(const CameraController&) = delete;
@@ -27,8 +28,9 @@ class CameraController
 		float roll;
 
 		// Callback IDs
-		uint64_t actionStartCallbackID;
-		uint64_t actionStopCallbackID;
+		mtd::EventCallbackHandle actionStartCallbackHandle;
+		mtd::EventCallbackHandle actionStopCallbackHandle;
+		mtd::EventCallbackHandle mousePositionCallbackHandle;
 
 		// Registers action event callbacks for camera input
 		void registerCallbacks();

--- a/Application/src/Events/CustomEventType.hpp
+++ b/Application/src/Events/CustomEventType.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-#include <meltdown/event.hpp>
-
-enum CustomEventType : uint64_t
-{
-	InvertSpin
-};

--- a/Application/src/Events/InvertSpinEvent.hpp
+++ b/Application/src/Events/InvertSpinEvent.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
-#include "CustomEventType.hpp"
+#include <meltdown/event.hpp>
 
-class InvertSpinEvent : public mtd::CustomEvent
+class InvertSpinEvent : public mtd::Event
 {
-	public:
-		virtual uint64_t getID() const override
-		{
-			return CustomEventType::InvertSpin;
-		}
 };

--- a/Application/src/Models/RotatingModel.cpp
+++ b/Application/src/Models/RotatingModel.cpp
@@ -3,23 +3,13 @@
 #include "../Actions.hpp"
 #include "../Events/InvertSpinEvent.hpp"
 
-RotatingModel::~RotatingModel()
-{
-	mtd::EventManager::removeCallback(mtd::EventType::ActionStart, callbackID);
-}
-
 void RotatingModel::start()
 {
-	callbackID = mtd::EventManager::addCallback
-	(
-		mtd::EventType::ActionStart, [&](const mtd::Event& e)
-		{
-			const mtd::ActionStartEvent* ase = dynamic_cast<const mtd::ActionStartEvent*>(&e);
-			if(!ase || ase->getAction() != Actions::Jump) return;
-
-			isJumping = true;
-		}
-	);
+	jumpCallbackHandle = mtd::EventManager::addCallback([&](const mtd::ActionStartEvent& event)
+	{
+		if(event.getAction() != Actions::Jump) return;
+		isJumping = true;
+	});
 }
 
 void RotatingModel::update(double deltaTime)
@@ -30,7 +20,7 @@ void RotatingModel::update(double deltaTime)
 	lightData.lightDirection.x -= 0.5f * deltaTime * lightData.lightDirection.z;
 	lightData.lightDirection.z += 0.5f * deltaTime * lightData.lightDirection.x;
 	lightData.ambientLightIntensity = 0.1f * lightData.lightDirection.z + 0.15f;
-	mtd::EventManager::dispatch(std::make_unique<mtd::UpdateDescriptorDataEvent>(0, 0, &lightData));
+	mtd::EventManager::dispatch<mtd::UpdateDescriptorDataEvent>(0, 0, &lightData);
 
 	if(isJumping)
 		jumpAnimation(static_cast<float>(deltaTime));
@@ -39,7 +29,7 @@ void RotatingModel::update(double deltaTime)
 	count++;
 	if(count >= 1000)
 	{
-		mtd::EventManager::dispatch(std::make_unique<InvertSpinEvent>());
+		mtd::EventManager::dispatch<InvertSpinEvent>();
 		count = 0;
 	}
 }

--- a/Application/src/Models/RotatingModel.hpp
+++ b/Application/src/Models/RotatingModel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <meltdown/event.hpp>
 #include <meltdown/model.hpp>
 
 // Data for the scene lightning
@@ -16,14 +17,12 @@ class RotatingModel : public mtd::Model
 	public:
 		using Model::Model;
 
-		virtual ~RotatingModel() override;
-
 		virtual void start() override;
 		virtual void update(double deltaTime) override;
 
 	private:
 		// ID of the callback for posterior deleting
-		uint64_t callbackID;
+		mtd::EventCallbackHandle jumpCallbackHandle;
 
 		// Flag for jumping animation
 		bool isJumping = false;

--- a/Application/src/Models/SpinningModel.cpp
+++ b/Application/src/Models/SpinningModel.cpp
@@ -1,25 +1,13 @@
 #include "SpinningModel.hpp"
 
-#include "../Events/CustomEventType.hpp"
-
-uint32_t SpinningModel::count = 0;
-
-SpinningModel::~SpinningModel()
-{
-	mtd::EventManager::removeCallback(CustomEventType::InvertSpin, callbackID);
-}
+#include "../Events/InvertSpinEvent.hpp"
 
 void SpinningModel::start()
 {
-	count++;
-	callbackID = mtd::EventManager::addCallback
-	(
-		CustomEventType::InvertSpin,
-		[&](const mtd::Event& e)
-		{
-			angularVelocity = -angularVelocity;
-		}
-	);
+	invertSpinCallbackHandle = mtd::EventManager::addCallback([&](const InvertSpinEvent& event)
+	{
+		angularVelocity = -angularVelocity;
+	});
 }
 
 void SpinningModel::update(double deltaTime)

--- a/Application/src/Models/SpinningModel.hpp
+++ b/Application/src/Models/SpinningModel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <meltdown/event.hpp>
 #include <meltdown/model.hpp>
 
 class SpinningModel : public mtd::Model
@@ -7,13 +8,10 @@ class SpinningModel : public mtd::Model
 	public:
 		using Model::Model;
 
-		virtual ~SpinningModel() override;
-
 		virtual void start() override;
 		virtual void update(double deltaTime) override;
 
 	private:
-		static uint32_t count;
-		uint64_t callbackID;
+		mtd::EventCallbackHandle invertSpinCallbackHandle;
 		float angularVelocity = 1.0f;
 };

--- a/Engine/include/meltdown/enums.hpp
+++ b/Engine/include/meltdown/enums.hpp
@@ -3,27 +3,6 @@
 namespace mtd
 {
 	/*
-	* @brief Enumeration of events types handled by the engine.
-	* New types of events should use the `Custom` variant.
-	*/
-	enum class EventType
-	{
-		KeyPress,
-		KeyRelease,
-		MousePosition,
-		ActionStart,
-		ActionStop,
-		WindowPosition,
-		SetPerspectiveCamera,
-		SetOrthographicCamera,
-		ChangeScene,
-		CreateInstances,
-		RemoveInstance,
-		UpdateDescriptorData,
-		Custom
-	};
-
-	/*
 	* @brief Identifier for the pipeline shader stage.
 	*/
 	enum class ShaderStage

--- a/Engine/src/Camera/Camera.cpp
+++ b/Engine/src/Camera/Camera.cpp
@@ -1,8 +1,6 @@
 #include <pch.hpp>
 #include "Camera.hpp"
 
-#include <meltdown/event.hpp>
-
 mtd::Camera::Camera(float aspectRatio)
 	: position{0.0f, 0.0f, 0.0f},
 	inputVelocity{0.0f, 0.0f, 0.0f}, maxSpeed{1.0f},
@@ -91,26 +89,20 @@ void mtd::Camera::updateProjectionMatrix()
 // Sets camera event callbacks
 void mtd::Camera::setEventCallbacks()
 {
-	EventManager::addCallback(EventType::SetPerspectiveCamera, [this](const Event& e)
+	setPerspectiveCameraCallbackHandle = EventManager::addCallback([this](const SetPerspectiveCameraEvent& event)
 	{
-		const SetPerspectiveCameraEvent* spce = dynamic_cast<const SetPerspectiveCameraEvent*>(&e);
-		if(!spce) return;
-
 		orthographicMode = false;
-		yFOV = spce->getFOV();
-		nearPlane = spce->getNearPlane();
-		farPlane = spce->getFarPlane();
+		yFOV = event.getFOV();
+		nearPlane = event.getNearPlane();
+		farPlane = event.getFarPlane();
 		updateProjectionMatrix();
 	});
 
-	EventManager::addCallback(EventType::SetOrthographicCamera, [this](const Event& e)
+	setOrthographicCameraCallbackHandle = EventManager::addCallback([this](const SetOrthographicCameraEvent& event)
 	{
-		const SetOrthographicCameraEvent* soce = dynamic_cast<const SetOrthographicCameraEvent*>(&e);
-		if(!soce) return;
-
 		orthographicMode = true;
-		viewWidth = soce->getViewWidth();
-		farPlane = soce->getFarPlane();
+		viewWidth = event.getViewWidth();
+		farPlane = event.getFarPlane();
 		updateProjectionMatrix();
 	});
 }

--- a/Engine/src/Camera/Camera.hpp
+++ b/Engine/src/Camera/Camera.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <meltdown/event.hpp>
+
 #include "../Utils/EngineStructs.hpp"
 #include "../Vulkan/Descriptors/DescriptorSetHandler.hpp"
 
@@ -68,6 +70,10 @@ namespace mtd
 
 			// Transformation matrices
 			CameraMatrices matrices;
+
+			// Event callback handles
+			EventCallbackHandle setPerspectiveCameraCallbackHandle;
+			EventCallbackHandle setOrthographicCameraCallbackHandle;
 
 			// Updates the view matrix
 			void updateViewMatrix();

--- a/Engine/src/Engine.cpp
+++ b/Engine/src/Engine.cpp
@@ -45,9 +45,6 @@ mtd::Engine::~Engine()
 {
 	device.getDevice().waitIdle();
 
-	EventManager::removeCallback(EventType::ChangeScene, changeSceneCallbackID);
-	EventManager::removeCallback(EventType::UpdateDescriptorData, updateDescriptorDataCallbackID);
-
 	LOG_INFO("Engine shut down.");
 }
 
@@ -118,15 +115,13 @@ void mtd::Engine::loadScene(const char* sceneFile)
 // Sets up event callback functions
 void mtd::Engine::configureEventCallbacks()
 {
-	changeSceneCallbackID = EventManager::addCallback(EventType::ChangeScene, [this](const Event& e)
+	changeSceneCallbackHandle = EventManager::addCallback([this](const ChangeSceneEvent& event)
 	{
-		const ChangeSceneEvent* cse = dynamic_cast<const ChangeSceneEvent*>(&e);
-		loadScene(cse->getSceneName());
+		loadScene(event.getSceneName());
 	});
-	updateDescriptorDataCallbackID = EventManager::addCallback(EventType::UpdateDescriptorData, [this](const Event& e)
+	updateDescriptorDataCallbackHandle = EventManager::addCallback([this](const UpdateDescriptorDataEvent& event)
 	{
-		const UpdateDescriptorDataEvent* udde = dynamic_cast<const UpdateDescriptorDataEvent*>(&e);
-		pipelines[udde->getPipelineIndex()].updateDescriptorData(udde->getBinding(), udde->getData());
+		pipelines[event.getPipelineIndex()].updateDescriptorData(event.getBinding(), event.getData());
 	});
 }
 

--- a/Engine/src/Engine.hpp
+++ b/Engine/src/Engine.hpp
@@ -55,9 +55,9 @@ namespace mtd
 			// Scene being currently rendered
 			Scene scene;
 
-			// Callback IDs
-			uint64_t changeSceneCallbackID;
-			uint64_t updateDescriptorDataCallbackID;
+			// Event callback handles
+			EventCallbackHandle changeSceneCallbackHandle;
+			EventCallbackHandle updateDescriptorDataCallbackHandle;
 
 			// Flag for updating the engine
 			bool shouldUpdateEngine;

--- a/Engine/src/Event/Event.cpp
+++ b/Engine/src/Event/Event.cpp
@@ -7,11 +7,6 @@ mtd::KeyPressEvent::KeyPressEvent(KeyCode keyCode, bool repeatedPress)
 {
 }
 
-mtd::EventType mtd::KeyPressEvent::getType() const
-{
-	return EventType::KeyPress;
-}
-
 mtd::KeyCode mtd::KeyPressEvent::getKeyCode() const
 {
 	return keyCode;
@@ -27,11 +22,6 @@ mtd::KeyReleaseEvent::KeyReleaseEvent(KeyCode keyCode) : keyCode{keyCode}
 {
 }
 
-mtd::EventType mtd::KeyReleaseEvent::getType() const
-{
-	return EventType::KeyRelease;
-}
-
 mtd::KeyCode mtd::KeyReleaseEvent::getKeyCode() const
 {
 	return keyCode;
@@ -41,11 +31,6 @@ mtd::KeyCode mtd::KeyReleaseEvent::getKeyCode() const
 mtd::MousePositionEvent::MousePositionEvent(float xPos, float yPos, bool cursorHidden)
 	: position{xPos, yPos}, cursorHidden{cursorHidden}
 {
-}
-
-mtd::EventType mtd::MousePositionEvent::getType() const
-{
-	return EventType::MousePosition;
 }
 
 const mtd::Vec2& mtd::MousePositionEvent::getMousePosition() const
@@ -63,11 +48,6 @@ mtd::ActionStartEvent::ActionStartEvent(uint32_t action) : action{action}
 {
 }
 
-mtd::EventType mtd::ActionStartEvent::getType() const
-{
-	return EventType::ActionStart;
-}
-
 uint32_t mtd::ActionStartEvent::getAction() const
 {
 	return action;
@@ -78,11 +58,6 @@ mtd::ActionStopEvent::ActionStopEvent(uint32_t action) : action{action}
 {
 }
 
-mtd::EventType mtd::ActionStopEvent::getType() const
-{
-	return EventType::ActionStop;
-}
-
 uint32_t mtd::ActionStopEvent::getAction() const
 {
 	return action;
@@ -91,11 +66,6 @@ uint32_t mtd::ActionStopEvent::getAction() const
 // Window position event
 mtd::WindowPositionEvent::WindowPositionEvent(int posX, int posY) : posX{posX}, posY{posY}
 {
-}
-
-mtd::EventType mtd::WindowPositionEvent::getType() const
-{
-	return EventType::WindowPosition;
 }
 
 int mtd::WindowPositionEvent::getPosX() const
@@ -112,11 +82,6 @@ int mtd::WindowPositionEvent::getPosY() const
 mtd::SetPerspectiveCameraEvent::SetPerspectiveCameraEvent(float yFOV, float nearPlane, float farPlane)
 	: yFOV{yFOV}, nearPlane{nearPlane}, farPlane{farPlane}
 {
-}
-
-mtd::EventType mtd::SetPerspectiveCameraEvent::getType() const
-{
-	return EventType::SetPerspectiveCamera;
 }
 
 float mtd::SetPerspectiveCameraEvent::getFOV() const
@@ -140,11 +105,6 @@ mtd::SetOrthographicCameraEvent::SetOrthographicCameraEvent(float viewWidth, flo
 {
 }
 
-mtd::EventType mtd::SetOrthographicCameraEvent::getType() const
-{
-	return EventType::SetOrthographicCamera;
-}
-
 float mtd::SetOrthographicCameraEvent::getViewWidth() const
 {
 	return viewWidth;
@@ -160,11 +120,6 @@ mtd::ChangeSceneEvent::ChangeSceneEvent(const char* sceneName) : sceneName{scene
 {
 }
 
-mtd::EventType mtd::ChangeSceneEvent::getType() const
-{
-	return EventType::ChangeScene;
-}
-
 const char* mtd::ChangeSceneEvent::getSceneName() const
 {
 	return sceneName;
@@ -174,11 +129,6 @@ const char* mtd::ChangeSceneEvent::getSceneName() const
 mtd::CreateInstancesEvent::CreateInstancesEvent(const char* modelID, uint32_t instanceCount)
 	: modelID{modelID}, instanceCount{instanceCount}
 {
-}
-
-mtd::EventType mtd::CreateInstancesEvent::getType() const
-{
-	return EventType::CreateInstances;
 }
 
 const std::string& mtd::CreateInstancesEvent::getModelID() const
@@ -196,11 +146,6 @@ mtd::RemoveInstanceEvent::RemoveInstanceEvent(uint64_t instanceID) : instanceID{
 {
 }
 
-mtd::EventType mtd::RemoveInstanceEvent::getType() const
-{
-	return EventType::RemoveInstance;
-}
-
 uint64_t mtd::RemoveInstanceEvent::getInstanceID() const
 {
 	return instanceID;
@@ -210,11 +155,6 @@ uint64_t mtd::RemoveInstanceEvent::getInstanceID() const
 mtd::UpdateDescriptorDataEvent::UpdateDescriptorDataEvent(uint32_t pipelineIndex, uint32_t binding, const void* data)
 	: pipelineIndex{pipelineIndex}, binding{binding}, data{data}
 {
-}
-
-mtd::EventType mtd::UpdateDescriptorDataEvent::getType() const
-{
-	return EventType::UpdateDescriptorData;
 }
 
 uint32_t mtd::UpdateDescriptorDataEvent::getPipelineIndex() const
@@ -230,10 +170,4 @@ uint32_t mtd::UpdateDescriptorDataEvent::getBinding() const
 const void* mtd::UpdateDescriptorDataEvent::getData() const
 {
 	return data;
-}
-
-// Custom event
-mtd::EventType mtd::CustomEvent::getType() const
-{
-	return EventType::Custom;
 }

--- a/Engine/src/GUIs/SettingsGui.cpp
+++ b/Engine/src/GUIs/SettingsGui.cpp
@@ -1,8 +1,6 @@
 #include <pch.hpp>
 #include "SettingsGui.hpp"
 
-#include <meltdown/event.hpp>
-
 static const std::array<const char*, 6> presentModeNames =
 {
 	"Immediate",
@@ -19,25 +17,19 @@ mtd::SettingsGui::SettingsGui(SwapchainSettings& swapchainSettings, const Camera
 	orthographicMode{camera.isOrthographic()}, nearPlane{camera.getNearPlane()}, farPlane{camera.getFarPlane()},
 	yFOV{camera.getFOV()}, viewWidth{camera.getViewWidth()}, updateCamera{false}
 {
-	EventManager::addCallback(EventType::SetPerspectiveCamera, [this](const Event& e)
+	EventManager::addCallback([this](const SetPerspectiveCameraEvent& event)
 	{
-		const SetPerspectiveCameraEvent* spce = dynamic_cast<const SetPerspectiveCameraEvent*>(&e);
-		if(!spce) return;
-
 		orthographicMode = false;
-		yFOV = spce->getFOV();
-		nearPlane = spce->getNearPlane();
-		farPlane = spce->getFarPlane();
+		yFOV = event.getFOV();
+		nearPlane = event.getNearPlane();
+		farPlane = event.getFarPlane();
 	});
 
-	EventManager::addCallback(EventType::SetOrthographicCamera, [this](const Event& e)
+	EventManager::addCallback([this](const SetOrthographicCameraEvent& event)
 	{
-		const SetOrthographicCameraEvent* soce = dynamic_cast<const SetOrthographicCameraEvent*>(&e);
-		if(!soce) return;
-
 		orthographicMode = true;
-		viewWidth = soce->getViewWidth();
-		farPlane = soce->getFarPlane();
+		viewWidth = event.getViewWidth();
+		farPlane = event.getFarPlane();
 	});
 }
 
@@ -145,8 +137,8 @@ void mtd::SettingsGui::cameraSettingsGui()
 	{
 		updateCamera = false;
 		if(orthographicMode)
-			EventManager::dispatch(std::make_unique<SetOrthographicCameraEvent>(viewWidth, farPlane));
+			EventManager::dispatch<SetOrthographicCameraEvent>(viewWidth, farPlane);
 		else
-			EventManager::dispatch(std::make_unique<SetPerspectiveCameraEvent>(yFOV, nearPlane, farPlane));
+			EventManager::dispatch<SetPerspectiveCameraEvent>(yFOV, nearPlane, farPlane);
 	}
 }

--- a/Engine/src/GUIs/SettingsGui.hpp
+++ b/Engine/src/GUIs/SettingsGui.hpp
@@ -31,6 +31,10 @@ namespace mtd
 			float viewWidth;
 			bool updateCamera;
 
+			// Camera mode callback handles
+			EventCallbackHandle setPerspectiveCallbackHandle;
+			EventCallbackHandle setOrthographicCallbackHandle;
+
 			// Settings subsections
 			void swapchainSettingsGui();
 			void cameraSettingsGui();

--- a/Engine/src/Input/InputHandler.cpp
+++ b/Engine/src/Input/InputHandler.cpp
@@ -3,8 +3,6 @@
 
 #include <meltdown/event.hpp>
 
-#include "../Window/Window.hpp"
-
 using ActionKeys = std::vector<mtd::KeyCode>;
 static std::unordered_map<uint32_t, ActionKeys> actionMappings;
 static std::unordered_map<mtd::KeyCode, bool> pressedKeys;
@@ -50,12 +48,12 @@ void mtd::InputHandler::checkActionEvents()
 		}
 		if(allKeysPressed && !actionStatuses[action])
 		{
-			EventManager::dispatch(std::make_unique<ActionStartEvent>(action));
+			EventManager::dispatch<ActionStartEvent>(action);
 			actionStatuses[action] = true;
 		}
 		else if(!allKeysPressed && actionStatuses[action])
 		{
-			EventManager::dispatch(std::make_unique<ActionStopEvent>(action));
+			EventManager::dispatch<ActionStopEvent>(action);
 			actionStatuses[action] = false;
 		}
 	}

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -105,17 +105,17 @@ void loadCamera(const nlohmann::json& cameraJson)
 {
 	if(cameraJson["orthographic"])
 	{
-		mtd::EventManager::dispatch(std::make_unique<mtd::SetOrthographicCameraEvent>
+		mtd::EventManager::dispatch<mtd::SetOrthographicCameraEvent>
 		(
 			cameraJson["view-width"], cameraJson["far-plane"]
-		));
+		);
 	}
 	else
 	{
-		mtd::EventManager::dispatch(std::make_unique<mtd::SetPerspectiveCameraEvent>
+		mtd::EventManager::dispatch<mtd::SetPerspectiveCameraEvent>
 		(
 			cameraJson["fov"], cameraJson["near-plane"], cameraJson["far-plane"]
-		));
+		);
 	}
 
 	mtd::CameraHandler::setPosition

--- a/Engine/src/Vulkan/ImGui/ImGuiHandler.cpp
+++ b/Engine/src/Vulkan/ImGui/ImGuiHandler.cpp
@@ -4,8 +4,6 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_vulkan.h>
 
-#include <meltdown/event.hpp>
-
 #include "../../Utils/Logger.hpp"
 
 mtd::ImGuiHandler::ImGuiHandler(const vk::Device& vulkanDevice)
@@ -95,20 +93,15 @@ void mtd::ImGuiHandler::createDescriptorPool()
 	poolSizesInfo[0].descriptorCount = 1;
 	poolSizesInfo[0].descriptorType = vk::DescriptorType::eCombinedImageSampler;
 
-	guiDescriptorPool.createDescriptorPool
-	(
-		poolSizesInfo, vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet
-	);
+	guiDescriptorPool.createDescriptorPool(poolSizesInfo, vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet);
 }
 
 // Configures the input logic for the GUI
 void mtd::ImGuiHandler::setInputCallbacks()
 {
-	EventManager::addCallback(EventType::KeyPress, [this](const Event& e)
+	toggleGuiCallbackHandle = EventManager::addCallback([this](const KeyPressEvent& event)
 	{
-		const KeyPressEvent* keyPress = dynamic_cast<const KeyPressEvent*>(&e);
-		if(!keyPress || keyPress->getKeyCode() != KeyCode::G) return;
-
-		showGui = !showGui;
+		if(event.getKeyCode() == KeyCode::G && !event.isRepeating())
+			showGui = !showGui;
 	});
 }

--- a/Engine/src/Vulkan/ImGui/ImGuiHandler.hpp
+++ b/Engine/src/Vulkan/ImGui/ImGuiHandler.hpp
@@ -40,6 +40,9 @@ namespace mtd
 			// List of windows to be rendered
 			std::vector<GuiWindow*> guiWindows;
 
+			// Toggle GUI event callback
+			EventCallbackHandle toggleGuiCallbackHandle;
+
 			// Checks ImGui Vulkan results
 			static void checkVulkanResult(VkResult result);
 

--- a/Engine/src/Window/Window.hpp
+++ b/Engine/src/Window/Window.hpp
@@ -3,6 +3,8 @@
 #include <vulkan/vulkan.hpp>
 #include <GLFW/glfw3.h>
 
+#include <meltdown/event.hpp>
+
 #include "../Utils/EngineStructs.hpp"
 
 namespace mtd
@@ -60,6 +62,10 @@ namespace mtd
 			// Last windowed mode settings before going fullscreen mode
 			WindowInfo savedWindowedInfo;
 
+			// Event callback handles
+			EventCallbackHandle keyPressCallbackHandle;
+			EventCallbackHandle windowPositionCallbackHandle;
+
 			// Configures GLFW parameters
 			void initializeGLFW() const;
 			// Creates GLFW window instance
@@ -67,9 +73,7 @@ namespace mtd
 
 			// Configures event dispatching on window callbacks
 			void setupWindowEventDispatching() const;
-			// Sets window input callbacks
-			void setInputCallbacks();
-			// Sets window event callbacks
+			// Configures the callbacks for window related events
 			void setWindowEventCallbacks();
 
 			// Toggles between fullscreen and windowed mode


### PR DESCRIPTION
- The base `Event` class no longer has a `getType()` function. Instead of returning an `enum`, the event type is now determined by the type ID.
- The `addCallback()` and `dispatch()` functions now have template versions to make the usage more simple and clean.
- The lifetime of the callbacks are more easily handled by using an `EventCallbackHandle` object, which deletes the callback once it is destroyed or the `removeCallback()` function is called.