### PR TITLE
Run update functions on a separate thread

### DIFF
--- a/Application/src/Models/RotatingModel.cpp
+++ b/Application/src/Models/RotatingModel.cpp
@@ -27,7 +27,7 @@ void RotatingModel::update(double deltaTime)
 
 	static uint32_t count = 0;
 	count++;
-	if(count >= 1000)
+	if(count >= 10000)
 	{
 		mtd::EventManager::dispatch<InvertSpinEvent>();
 		count = 0;

--- a/Engine/include/Meltdown.hpp
+++ b/Engine/include/Meltdown.hpp
@@ -67,7 +67,7 @@ namespace mtd
 			void setVSync(bool enableVSync);
 
 			/*
-			* @brief Begins the engine main loop, transfering the application control to the engine.
+			* @brief Begins the engine main loop, returning only when the window is closed.
 			*
 			* @param onUpdateCallback Callback function called on every engine update.
 			*/

--- a/Engine/pch/pch.hpp
+++ b/Engine/pch/pch.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <fstream>
 #include <functional>
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 

--- a/Engine/src/Camera/Camera.hpp
+++ b/Engine/src/Camera/Camera.hpp
@@ -3,7 +3,6 @@
 #include <meltdown/event.hpp>
 
 #include "../Utils/EngineStructs.hpp"
-#include "../Vulkan/Descriptors/DescriptorSetHandler.hpp"
 
 namespace mtd
 {
@@ -41,8 +40,8 @@ namespace mtd
 			// Applies the rotation described in the quaternion on the camera orientation
 			void rotate(const Quaternion& quaternion) { orientation = quaternion * orientation; }
 
-			// Updates the camera matrices
-			void updateCamera(DescriptorSetHandler* pGlobalDescriptorSet);
+			// Updates the camera matrices and returns a pointer to the matrices
+			const void* fetchUpdatedMatrices();
 
 		private:
 			// Current camera location
@@ -56,7 +55,7 @@ namespace mtd
 			float maxSpeed;
 
 			// Camera aspect ratio
-			float aspectRatio;
+			std::atomic<float> aspectRatio;
 			// Camera vertical FOV, in degrees
 			float yFOV;
 			// Orthographic camera view width
@@ -70,6 +69,7 @@ namespace mtd
 
 			// Transformation matrices
 			CameraMatrices matrices;
+			std::mutex matricesMutex;
 
 			// Event callback handles
 			EventCallbackHandle setPerspectiveCameraCallbackHandle;

--- a/Engine/src/Engine.hpp
+++ b/Engine/src/Engine.hpp
@@ -59,8 +59,20 @@ namespace mtd
 			EventCallbackHandle changeSceneCallbackHandle;
 			EventCallbackHandle updateDescriptorDataCallbackHandle;
 
+			// Flag to ensure all threads finish executing
+			std::atomic<bool> running;
 			// Flag for updating the engine
 			bool shouldUpdateEngine;
+
+			// Descriptors to update before rendering the next frame
+			std::unordered_map<uint64_t, const void*> pendingDescriptorUpdates;
+			std::mutex pendingDescriptorUpdateMutex;
+
+			// Runs the update loop (update thread)
+			void updateLoop(const std::function<void(double)>& onUpdateCallback);
+
+			// Applies all the pending updates for the descriptors
+			void updateDescriptors();
 
 			// Sets up event callback functions
 			void configureEventCallbacks();

--- a/Engine/src/Event/EventManager.cpp
+++ b/Engine/src/Event/EventManager.cpp
@@ -8,6 +8,7 @@ static std::unordered_map<std::type_index, EventCallbackMap> callbackMaps;
 static uint64_t currentCallbackIndex = 1;
 
 static std::queue<std::unique_ptr<mtd::Event>> eventQueue;
+static std::mutex eventQueueMutex;
 
 mtd::EventCallbackHandle::EventCallbackHandle() : eventType{typeid(void)}, callbackID{0}
 {
@@ -56,11 +57,13 @@ mtd::EventCallbackHandle mtd::EventManager::addCallback(std::type_index eventTyp
 
 void mtd::EventManager::dispatch(std::unique_ptr<Event> pEvent)
 {
+	std::lock_guard eventQueueLock{eventQueueMutex};
 	eventQueue.push(std::move(pEvent));
 }
 
 void mtd::EventManager::processEvents()
 {
+	std::lock_guard eventQueueLock{eventQueueMutex};
 	while(!eventQueue.empty())
 	{
 		std::unique_ptr<Event> pEvent = std::move(eventQueue.front());

--- a/Engine/src/Input/InputHandler.cpp
+++ b/Engine/src/Input/InputHandler.cpp
@@ -6,6 +6,7 @@
 using ActionKeys = std::vector<mtd::KeyCode>;
 static std::unordered_map<uint32_t, ActionKeys> actionMappings;
 static std::unordered_map<mtd::KeyCode, bool> pressedKeys;
+static std::mutex pressedKeysMutex;
 static std::unordered_map<uint32_t, bool> actionStatuses;
 
 // Defines the keys that needs to be pressed to trigger an action
@@ -23,12 +24,14 @@ void mtd::InputHandler::unmapAction(uint32_t action)
 // Adds key to the list of pressed keys
 void mtd::InputHandler::keyPressed(KeyCode keyCode)
 {
+	std::lock_guard lock{pressedKeysMutex};
 	pressedKeys[keyCode] = true;
 }
 
 // Removes key from the list of pressed keys
 void mtd::InputHandler::keyReleased(KeyCode keyCode)
 {
+	std::lock_guard lock{pressedKeysMutex};
 	pressedKeys[keyCode] = false;
 }
 
@@ -40,6 +43,7 @@ void mtd::InputHandler::checkActionEvents()
 		bool allKeysPressed = true;
 		for(KeyCode key: keyList)
 		{
+			std::lock_guard lock{pressedKeysMutex};
 			if(!pressedKeys[key])
 			{
 				allKeysPressed = false;

--- a/Engine/src/Utils/Profiler.cpp
+++ b/Engine/src/Utils/Profiler.cpp
@@ -1,8 +1,6 @@
 #include <pch.hpp>
 #include "Profiler.hpp"
 
-#include <chrono>
-
 using ChronoClock = std::chrono::steady_clock;
 using ChronoTime = ChronoClock::time_point;
 using ChronoDuration = std::chrono::duration<float, std::milli>;

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
@@ -106,6 +106,13 @@ void mtd::DescriptorSetHandler::updateDescriptorData
 	uint32_t swappableSetIndex, uint32_t binding, const void* data, vk::DeviceSize dataSize
 ) const
 {
+	assert
+	(
+		swappableSetIndex < resourcesList.size() &&
+		binding < resourcesList[swappableSetIndex].size() &&
+		"Descriptor out of bounds for data update."
+	);
+
 	const std::unique_ptr<GpuBuffer>& buffer = resourcesList[swappableSetIndex][binding].descriptorBuffer;
 	buffer->copyMemoryToBuffer(dataSize, data);
 }

--- a/Engine/src/Vulkan/Instance/DebugMessenger.cpp
+++ b/Engine/src/Vulkan/Instance/DebugMessenger.cpp
@@ -34,17 +34,18 @@
 
 		switch(messageSeverity)
 		{
+			using namespace mtd;
 			case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
-				mtd::LOG_VERBOSE(message.c_str());
+				LOG_VERBOSE(message.c_str());
 				break;
 			case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
-				mtd::LOG_INFO(message.c_str());
+				LOG_INFO(message.c_str());
 				break;
 			case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
-				mtd::LOG_WARNING(message.c_str());
+				LOG_WARNING(message.c_str());
 				break;
 			case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
-				mtd::LOG_ERROR(message.c_str());
+				LOG_ERROR(message.c_str());
 				break;
 		}
 
@@ -55,7 +56,7 @@
 	void mtd::DebugMessenger::createDebugMessenger
 	(
 		const vk::Instance& instance,
-		const vk::DispatchLoaderDynamic* pDispatchLoader,
+		const vk::detail::DispatchLoaderDynamic* pDispatchLoader,
 		vk::DebugUtilsMessengerEXT* pDebugMessenger
 	)
 	{
@@ -66,7 +67,7 @@
 		debugMessengerInfo.messageType = vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral |
 			vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation |
 			vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
-		debugMessengerInfo.pfnUserCallback = (PFN_vkDebugUtilsMessengerCallbackEXT) debugCallback;
+		debugMessengerInfo.pfnUserCallback = (vk::PFN_DebugUtilsMessengerCallbackEXT) debugCallback;
 
 		if(instance.createDebugUtilsMessengerEXT
 		(

--- a/Engine/src/Vulkan/Instance/DebugMessenger.hpp
+++ b/Engine/src/Vulkan/Instance/DebugMessenger.hpp
@@ -11,7 +11,7 @@
 		void createDebugMessenger
 		(
 			const vk::Instance& instance,
-			const vk::DispatchLoaderDynamic* pDispatchLoader,
+			const vk::detail::DispatchLoaderDynamic* pDispatchLoader,
 			vk::DebugUtilsMessengerEXT* pDebugMessenger
 		);
 	}

--- a/Engine/src/Vulkan/Instance/VulkanInstance.cpp
+++ b/Engine/src/Vulkan/Instance/VulkanInstance.cpp
@@ -44,7 +44,7 @@ mtd::VulkanInstance::VulkanInstance(const EngineInfo& info, const Window& window
 		throw std::runtime_error("Failed to create Vulkan instance.\n");
 	LOG_INFO("Vulkan instance created.\n");
 
-	dispatchLoader = std::make_unique<vk::DispatchLoaderDynamic>(instance, vkGetInstanceProcAddr);
+	dispatchLoader = std::make_unique<vk::detail::DispatchLoaderDynamic>(instance, vkGetInstanceProcAddr);
 	#ifdef MTD_DEBUG
 		DebugMessenger::createDebugMessenger(instance, dispatchLoader.get(), &debugMessenger);
 	#endif
@@ -68,7 +68,7 @@ uint32_t mtd::VulkanInstance::checkVulkanVersion() const
 {
 	uint32_t version = 0;
 	vk::Result result = vk::enumerateInstanceVersion(&version);
-	uint32_t requestedVersion = VK_MAKE_API_VERSION(0, 1, 3, 0);
+	uint32_t requestedVersion = VK_MAKE_API_VERSION(0, 1, 4, 0);
 
 	LOG_VERBOSE
 	(
@@ -108,10 +108,8 @@ bool mtd::VulkanInstance::supports
 	std::vector<const char*> requiredLayers
 )
 {
-	std::vector<vk::ExtensionProperties> supportedExtensions =
-		vk::enumerateInstanceExtensionProperties();
-	std::vector<vk::LayerProperties> supportedLayers =
-		vk::enumerateInstanceLayerProperties();
+	std::vector<vk::ExtensionProperties> supportedExtensions = vk::enumerateInstanceExtensionProperties();
+	std::vector<vk::LayerProperties> supportedLayers = vk::enumerateInstanceLayerProperties();
 
 	bool found;
 	for(const char* requiredExtension: requiredExtensions)

--- a/Engine/src/Vulkan/Instance/VulkanInstance.hpp
+++ b/Engine/src/Vulkan/Instance/VulkanInstance.hpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <meltdown/structs.hpp>
-#include <vulkan/vulkan.hpp>
 
 #include "../../Window/Window.hpp"
 
@@ -28,7 +27,7 @@ namespace mtd
 			vk::Instance instance;
 
 			// Dispatch loader dynamic instance
-			std::unique_ptr<vk::DispatchLoaderDynamic> dispatchLoader;
+			std::unique_ptr<vk::detail::DispatchLoaderDynamic> dispatchLoader;
 			// Vulkan debug messenger (it depends on the validation layer)
 			vk::DebugUtilsMessengerEXT debugMessenger;
 

--- a/Engine/src/Vulkan/Render/Renderer.cpp
+++ b/Engine/src/Vulkan/Render/Renderer.cpp
@@ -26,7 +26,7 @@ void mtd::Renderer::render
 	bool& shouldUpdateEngine
 )
 {
-	PROFILER_NEXT_STAGE("Render - Aquire frame");
+	PROFILER_NEXT_STAGE("Render - Acquire frame");
 
 	const vk::Device& device = mtdDevice.getDevice();
 	const Frame& frame = swapchain.getFrame(currentFrameIndex);
@@ -63,8 +63,7 @@ void mtd::Renderer::render
 	}
 
 	swapchain.getFrame(currentFrameIndex).fetchFrameDrawData(drawInfo);
-	const CommandHandler& commandHandler =
-		swapchain.getFrame(currentFrameIndex).getCommandHandler();
+	const CommandHandler& commandHandler = swapchain.getFrame(currentFrameIndex).getCommandHandler();
 
 	recordDrawCommand(pipelines, scene, commandHandler, drawInfo, guiHandler);
 	commandHandler.submitDrawCommandBuffer(*(drawInfo.syncBundle));
@@ -77,8 +76,7 @@ void mtd::Renderer::render
 		drawInfo.syncBundle->renderFinished
 	);
 
-	currentFrameIndex =
-		shouldUpdateEngine ? 0 : (currentFrameIndex + 1) % swapchain.getFrameCount();
+	currentFrameIndex = shouldUpdateEngine ? 0 : (currentFrameIndex + 1) % swapchain.getFrameCount();
 }
 
 // Records draw command to the command buffer
@@ -112,7 +110,6 @@ void mtd::Renderer::recordDrawCommand
 
 	commandBuffer.beginRenderPass(&renderPassBeginInfo, vk::SubpassContents::eInline);
 
-	// Global descriptor set
 	commandBuffer.bindDescriptorSets
 	(
 		vk::PipelineBindPoint::eGraphics,
@@ -127,8 +124,8 @@ void mtd::Renderer::recordDrawCommand
 	{
 		PROFILER_NEXT_STAGE(pipelines[i].getName().c_str());
 		const MeshManager* pMeshManager = scene.getMeshManager(i);
-		if(pMeshManager->getMeshCount() == 0)
-			continue;
+
+		if(pMeshManager->getMeshCount() == 0) continue;
 
 		pipelines[i].bind(commandBuffer);
 		pipelines[i].bindPipelineDescriptors(commandBuffer);
@@ -159,6 +156,10 @@ void mtd::Renderer::presentFrame
 	presentInfo.pResults = nullptr;
 
 	vk::Result result = presentQueue.presentKHR(&presentInfo);
-	if(result != vk::Result::eSuccess && result != vk::Result::eErrorOutOfDateKHR)
-		LOG_ERROR("Failed to present frame to screen. Vulkan result: %d", result);
+	if
+	(
+		result != vk::Result::eSuccess &&
+		result != vk::Result::eErrorOutOfDateKHR &&
+		result != vk::Result::eSuboptimalKHR
+	) LOG_ERROR("Failed to present frame to screen. Vulkan result: %d", result);
 }

--- a/Engine/src/Window/Window.hpp
+++ b/Engine/src/Window/Window.hpp
@@ -24,7 +24,7 @@ namespace mtd
 			float getAspectRatio() const { return aspectRatio; }
 
 			// Polls events and checks if window should be kept open
-			bool keepOpen() const;
+			bool keepOpen();
 			// Checks if a specific key is pressed
 			bool isKeyPressed(int glfwKeyCode) const
 				{ return glfwGetKey(glfwWindow, glfwKeyCode) == GLFW_PRESS; }
@@ -54,10 +54,15 @@ namespace mtd
 			// Window aspect ratio
 			float aspectRatio;
 
-			// True if cursor is not visible
+			// Cursor visibility status
 			bool cursorHidden;
-			// True if window is in fullscreen mode
+			// Window fullscreen mode status
 			bool fullscreenMode;
+
+			// Flag to set input mode
+			bool shouldSetInputMode;
+			// Flag to toggle fullscreen
+			bool shouldToggleFullscreen;
 
 			// Last windowed mode settings before going fullscreen mode
 			WindowInfo savedWindowedInfo;


### PR DESCRIPTION
The engine main loop has been divided into a render thread and an update thread, allowing the framerate to not depend on the update logic.