### PR TITLE
Improve material system

### DIFF
--- a/Engine/src/Material/Material.cpp
+++ b/Engine/src/Material/Material.cpp
@@ -25,6 +25,13 @@ mtd::Material::Material(Material&& other) noexcept
 	textures{std::move(other.textures)}
 {}
 
+// Fetches the texture paths for the material
+void mtd::Material::fetchTexturePaths(std::vector<std::string>& textureFilePaths) const
+{
+	for(const auto& [textureType, texturePath]: texturePaths)
+		textureFilePaths.emplace_back(texturePath.c_str());
+}
+
 // Inserts a float attribute data
 void mtd::Material::addFloatData(MaterialFloatDataType floatDataType, const float* data)
 {

--- a/Engine/src/Material/Material.hpp
+++ b/Engine/src/Material/Material.hpp
@@ -21,6 +21,9 @@ namespace mtd
 			size_t getFloatAttributesSize() const { return floatAttributes.size(); }
 			uint32_t getTextureCount() const { return static_cast<uint32_t>(textureTypes.size()); }
 
+			// Fetches the texture paths for the material
+			void fetchTexturePaths(std::vector<std::string>& textureFilePaths) const;
+
 			// Checks if the material has float data attributes
 			bool hasFloatData() const { return !floatAttributeTypes.empty(); }
 

--- a/Engine/src/Material/Material.hpp
+++ b/Engine/src/Material/Material.hpp
@@ -16,7 +16,9 @@ namespace mtd
 
 			Material(Material&& other) noexcept;
 
-			// Getter
+			// Getters
+			const float* getFloatAttributesData() const { return floatAttributes.data(); }
+			size_t getFloatAttributesSize() const { return floatAttributes.size(); }
 			uint32_t getTextureCount() const { return static_cast<uint32_t>(textureTypes.size()); }
 
 			// Checks if the material has float data attributes

--- a/Engine/src/Material/MaterialLump.cpp
+++ b/Engine/src/Material/MaterialLump.cpp
@@ -2,25 +2,49 @@
 #include "MaterialLump.hpp"
 
 mtd::MaterialLump::MaterialLump(const Device& mtdDevice, const MaterialInfo& materialInfo)
-	: materialInfo{materialInfo},
+	: mtdDevice{mtdDevice},
+	materialInfo{materialInfo},
 	floatDataBuffer{mtdDevice, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
 	materialCount{0U}
 {}
 
 // Loads material float data and textures
-void mtd::MaterialLump::addMaterial(const float* data, size_t size)
+void mtd::MaterialLump::addMaterial(const float* data, size_t size, const std::vector<std::string>& texturePaths)
 {
 	floatMaterialAttributes.insert(floatMaterialAttributes.cend(), data, data + size);
+
+	assert
+	(
+		materialInfo.textureTypes.size() == texturePaths.size() &&
+		"The number of textures should match the material type."
+	);
+
+	for(const std::string& texturePath: texturePaths)
+		textures.emplace_back(mtdDevice, texturePath.c_str());
+
 	materialCount++;
 }
 
-// Assigns the material buffer as a descriptor
-void mtd::MaterialLump::assignBufferToDescriptor
+// Assigns the material float data buffer as a descriptor
+void mtd::MaterialLump::assignFloatDataBufferToDescriptor
 (
 	DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
 ) const
 {
 	descriptorSetHandler.assignExternalResourcesToDescriptor(swappableSetIndex, bindingIndex, floatDataBuffer);
+}
+
+// Assigns the material textures to a descriptor
+void mtd::MaterialLump::assignTexturesToDescriptor
+(
+	DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
+) const
+{
+	std::vector<vk::DescriptorImageInfo> descriptorImageInfos;
+	for(const Texture& texture: textures)
+		descriptorImageInfos.emplace_back(texture.getDescriptorImageInfo());
+
+	descriptorSetHandler.createImagesDescriptorResources(swappableSetIndex, bindingIndex, descriptorImageInfos);
 }
 
 // Loads all materials to the GPU VRAM
@@ -31,4 +55,7 @@ void mtd::MaterialLump::loadMaterialsToGPU(const CommandHandler& commandHandler)
 		commandHandler, sizeof(float) * floatMaterialAttributes.size(), floatMaterialAttributes.data()
 	);
 	floatMaterialAttributes.clear();
+
+	for(Texture& texture: textures)
+		texture.loadToGpu(mtdDevice, commandHandler);
 }

--- a/Engine/src/Material/MaterialLump.cpp
+++ b/Engine/src/Material/MaterialLump.cpp
@@ -1,0 +1,34 @@
+#include <pch.hpp>
+#include "MaterialLump.hpp"
+
+mtd::MaterialLump::MaterialLump(const Device& mtdDevice, const MaterialInfo& materialInfo)
+	: materialInfo{materialInfo},
+	floatDataBuffer{mtdDevice, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
+	materialCount{0U}
+{}
+
+// Loads material float data and textures
+void mtd::MaterialLump::addMaterial(const float* data, size_t size)
+{
+	floatMaterialAttributes.insert(floatMaterialAttributes.cend(), data, data + size);
+	materialCount++;
+}
+
+// Assigns the material buffer as a descriptor
+void mtd::MaterialLump::assignBufferToDescriptor
+(
+	DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
+) const
+{
+	descriptorSetHandler.assignExternalResourcesToDescriptor(swappableSetIndex, bindingIndex, floatDataBuffer);
+}
+
+// Loads all materials to the GPU VRAM
+void mtd::MaterialLump::loadMaterialsToGPU(const CommandHandler& commandHandler)
+{
+	floatDataBuffer.createDeviceLocal
+	(
+		commandHandler, sizeof(float) * floatMaterialAttributes.size(), floatMaterialAttributes.data()
+	);
+	floatMaterialAttributes.clear();
+}

--- a/Engine/src/Material/MaterialLump.hpp
+++ b/Engine/src/Material/MaterialLump.hpp
@@ -8,7 +8,7 @@ namespace mtd
 	class MaterialLump
 	{
 		public:
-			MaterialLump(const mtd::Device& mtdDevice, const MaterialInfo& materialInfo);
+			MaterialLump(const Device& mtdDevice, const MaterialInfo& materialInfo);
 			~MaterialLump() = default;
 
 			MaterialLump(const MaterialLump&) = delete;
@@ -17,21 +17,26 @@ namespace mtd
 			// Getters
 			const MaterialInfo& getMaterialInfo() const { return materialInfo; }
 			uint32_t getMaterialCount() const { return materialCount; }
-			uint32_t getTextureCount() const { return static_cast<uint32_t>(materialTextures.size()); }
+			uint32_t getTextureCount() const { return static_cast<uint32_t>(textures.size()); }
 
 			// Checks if the material type has float data attributes
 			bool hasFloatData() const { return floatMaterialAttributes.size() != 0; }
 
 			// Loads material float data and textures
-			void addMaterial(const float* data, size_t size);
+			void addMaterial(const float* data, size_t size, const std::vector<std::string>& texturePaths);
 
-			// Assigns the material buffer as a descriptor
-			void assignBufferToDescriptor
+			// Assigns the material float data buffer as a descriptor
+			void assignFloatDataBufferToDescriptor
+			(
+				DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
+			) const;
+			// Assigns the material textures to a descriptor
+			void assignTexturesToDescriptor
 			(
 				DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
 			) const;
 
-			// Loads all materials to the GPU VRAM
+			// Loads all materials to the VRAM
 			void loadMaterialsToGPU(const CommandHandler& commandHandler);
 
 		private:
@@ -41,12 +46,15 @@ namespace mtd
 			// Buffer data for float attributes of all materials
 			std::vector<float> floatMaterialAttributes;
 			// List for the texture of all materials
-			std::vector<Texture> materialTextures;
+			std::vector<Texture> textures;
 
 			// Buffers
 			GpuBuffer floatDataBuffer;
 
 			// Counter for the materials in the lump
 			uint32_t materialCount;
+
+			// Device reference
+			const Device& mtdDevice;
 	};
 }

--- a/Engine/src/Material/MaterialLump.hpp
+++ b/Engine/src/Material/MaterialLump.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../Vulkan/Image/Texture.hpp"
+
+namespace mtd
+{
+	// Manages all materials of the same mesh manager
+	class MaterialLump
+	{
+		public:
+			MaterialLump(const mtd::Device& mtdDevice, const MaterialInfo& materialInfo);
+			~MaterialLump() = default;
+
+			MaterialLump(const MaterialLump&) = delete;
+			MaterialLump& operator=(const MaterialLump&) = delete;
+
+			// Getters
+			const MaterialInfo& getMaterialInfo() const { return materialInfo; }
+			uint32_t getMaterialCount() const { return materialCount; }
+			uint32_t getTextureCount() const { return static_cast<uint32_t>(materialTextures.size()); }
+
+			// Checks if the material type has float data attributes
+			bool hasFloatData() const { return floatMaterialAttributes.size() != 0; }
+
+			// Loads material float data and textures
+			void addMaterial(const float* data, size_t size);
+
+			// Assigns the material buffer as a descriptor
+			void assignBufferToDescriptor
+			(
+				DescriptorSetHandler& descriptorSetHandler, uint32_t swappableSetIndex, uint32_t bindingIndex
+			) const;
+
+			// Loads all materials to the GPU VRAM
+			void loadMaterialsToGPU(const CommandHandler& commandHandler);
+
+		private:
+			// Information about the material data
+			MaterialInfo materialInfo;
+
+			// Buffer data for float attributes of all materials
+			std::vector<float> floatMaterialAttributes;
+			// List for the texture of all materials
+			std::vector<Texture> materialTextures;
+
+			// Buffers
+			GpuBuffer floatDataBuffer;
+
+			// Counter for the materials in the lump
+			uint32_t materialCount;
+	};
+}

--- a/Engine/src/Scene/Scene.cpp
+++ b/Engine/src/Scene/Scene.cpp
@@ -81,7 +81,7 @@ void mtd::Scene::allocateResources
 		i++;
 	}
 
-	descriptorPool.createDescriptorPool(poolSizesInfo);
+	descriptorPool.createDescriptorPool(poolSizesInfo, vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet);
 
 	for(uint32_t i = 0; i < graphicsPipelines.size(); i++)
 	{
@@ -104,7 +104,11 @@ void mtd::Scene::allocateResources
 	{
 		DescriptorSetHandler& descriptorSetHandler = rayTracingPipelines[i].getDescriptorSetHandler(0);
 		descriptorSetHandler.defineDescriptorSetsAmount(1);
-		descriptorPool.allocateDescriptorSet(descriptorSetHandler);
+
+		vk::DescriptorSetVariableDescriptorCountAllocateInfo variableCountInfo{};
+		variableCountInfo.descriptorSetCount = 1U;
+		variableCountInfo.pDescriptorCounts = &totalImageSamplerCount;
+		descriptorPool.allocateDescriptorSet(descriptorSetHandler, &variableCountInfo);
 
 		meshManagers[graphicsPipelines.size() + i]->loadMeshes(descriptorSetHandler);
 	}

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -461,8 +461,10 @@ void loadRayTracingMeshes
 	std::vector<std::unique_ptr<mtd::MeshManager>>& meshManagers
 )
 {
-	meshManagers.emplace_back(std::make_unique<mtd::RayTracingMeshManager>(device));
 	mtd::MaterialInfo materialInfo{rtPipelineInfo.materialFloatDataTypes, rtPipelineInfo.materialTextureTypes};
+	meshManagers.emplace_back(std::make_unique<mtd::RayTracingMeshManager>(device, materialInfo));
+
+	mtd::RayTracingMeshManager* pMeshManager = dynamic_cast<mtd::RayTracingMeshManager*>(meshManagers.back().get());
 
 	for(uint32_t i = 0; i < rtMeshListJson.size(); i++)
 	{
@@ -473,8 +475,6 @@ void loadRayTracingMeshes
 		const std::vector<mtd::Mat4x4>* pPreTransforms =
 			reinterpret_cast<const std::vector<mtd::Mat4x4>*>(&preTransforms);
 
-		std::vector<mtd::RayTracingMesh>& meshes =
-			dynamic_cast<mtd::RayTracingMeshManager*>(meshManagers.back().get())->getMeshes();
-		meshes.emplace_back(device, i, id.c_str(), file.c_str(), materialInfo, *pPreTransforms);
+		pMeshManager->createNewMesh(i, id.c_str(), file.c_str(), *pPreTransforms);
 	}
 }

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rgen
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rgen
@@ -1,6 +1,17 @@
 #version 460
-#extension GL_EXT_ray_tracing : require
-#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_ray_tracing : enable
+#extension GL_EXT_shader_16bit_storage : enable
+
+struct Vertex
+{
+	vec3 position;
+	vec2 textureUV;
+};
+
+struct MaterialFloatAttributes
+{
+	vec4 diffuse;
+};
 
 layout(set = 0, binding = 0) uniform CameraMatrices
 {
@@ -8,12 +19,6 @@ layout(set = 0, binding = 0) uniform CameraMatrices
 	mat4 view;
 	mat4 projectionView;
 } camera;
-
-struct Vertex
-{
-	vec3 position;
-	vec2 textureUV;
-};
 
 layout(set = 1, binding = 0, rgba8) uniform image2D storageImage;
 layout(set = 1, binding = 1) buffer VertexBuffer
@@ -28,24 +33,15 @@ layout(set = 1, binding = 3) buffer MaterialIndexBuffer
 {
 	uint16_t materialIDs[];
 };
-layout(set = 1, binding = 4) uniform MaterialData
+layout(set = 1, binding = 4) buffer MaterialsFloatBuffer
 {
-	vec4 diffuseColor;
-} materialData;
+	MaterialFloatAttributes materialFloatAttributes[];
+};
 
 struct Ray
 {
 	vec3 origin;
 	vec3 direction;
-};
-
-const vec3 colors[5] =
-{
-	vec3(0.0f, 0.3f, 0.0f),
-	vec3(1.0f, 1.0f, 1.0f),
-	vec3(0.5f, 0.5f, 0.5f),
-	vec3(0.45f, 0.0f, 0.0f),
-	vec3(0.8f, 0.75f, 0.6f)
 };
 
 bool intersectTriangle(Ray ray, Vertex v0, Vertex v1, Vertex v2, out float hitDistance)
@@ -85,7 +81,7 @@ void main()
 	ray.origin = invView[3].xyz;
 	ray.direction = normalize((invView * (farPoint / farPoint.w)).xyz - ray.origin);
 
-	vec3 color = vec3(0.0f, 0.0f, 0.0f);
+	vec4 color = vec4(0.0f, 0.0f, 0.0f, 1.0f);
 	float closestHit = 1e9;
 
 	int triangleCount = indices.length() / 3;
@@ -99,9 +95,9 @@ void main()
 		if(intersectTriangle(ray, v0, v1, v2, hitDistance) && hitDistance < closestHit)
 		{
 			closestHit = hitDistance;
-			color = colors[uint(materialIDs[i])];
+			color = materialFloatAttributes[uint(materialIDs[i])].diffuse;
 		}
 	}
 
-	imageStore(storageImage, ivec2(pixelCoord), vec4(color, 1.0f));
+	imageStore(storageImage, ivec2(pixelCoord), color);
 }

--- a/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
@@ -5,8 +5,7 @@
 
 mtd::DescriptorPool::DescriptorPool(const vk::Device& device)
 	: device{device}, isClear{true}
-{
-}
+{}
 
 mtd::DescriptorPool::~DescriptorPool()
 {
@@ -36,27 +35,27 @@ void mtd::DescriptorPool::createDescriptorPool
 	descriptorPoolCreateInfo.pPoolSizes = poolSizes.data();
 
 	isClear = false;
-	vk::Result result =
-		device.createDescriptorPool(&descriptorPoolCreateInfo, nullptr, &descriptorPool);
+	vk::Result result = device.createDescriptorPool(&descriptorPoolCreateInfo, nullptr, &descriptorPool);
 	if(result != vk::Result::eSuccess)
 		LOG_ERROR("Failed to create descriptor pool. Vulkan result: %d", result);
 }
 
 // Allocates descriptor sets in the pool
-void mtd::DescriptorPool::allocateDescriptorSet(DescriptorSetHandler& descriptorSetHandler) const
+void mtd::DescriptorPool::allocateDescriptorSet
+(
+	DescriptorSetHandler& descriptorSetHandler,
+	const void* pExtraAllocateInfo
+) const
 {
-	std::vector<vk::DescriptorSetLayout> layouts
-	{
-		descriptorSetHandler.getSetCount(), descriptorSetHandler.getLayout()
-	};
+	std::vector<vk::DescriptorSetLayout> layouts{descriptorSetHandler.getSetCount(), descriptorSetHandler.getLayout()};
 
 	vk::DescriptorSetAllocateInfo setAllocateInfo{};
 	setAllocateInfo.descriptorPool = descriptorPool;
 	setAllocateInfo.descriptorSetCount = descriptorSetHandler.getSetCount();
 	setAllocateInfo.pSetLayouts = layouts.data();
+	setAllocateInfo.pNext = pExtraAllocateInfo;
 
-	vk::Result result =
-		device.allocateDescriptorSets(&setAllocateInfo, descriptorSetHandler.getSets().data());
+	vk::Result result = device.allocateDescriptorSets(&setAllocateInfo, descriptorSetHandler.getSets().data());
 	if(result != vk::Result::eSuccess)
 		LOG_ERROR("Failed to allocate descriptor set. Vulkan result: %d", result);
 }

--- a/Engine/src/Vulkan/Descriptors/DescriptorPool.hpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorPool.hpp
@@ -32,7 +32,11 @@ namespace mtd
 			);
 
 			// Allocates a descriptor set in the pool
-			void allocateDescriptorSet(DescriptorSetHandler& descriptorSetHandler) const;
+			void allocateDescriptorSet
+			(
+				DescriptorSetHandler& descriptorSetHandler,
+				const void* pExtraAllocateInfo = nullptr
+			) const;
 
 			// Clears the descriptor pool and its sets
 			void clear();

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.hpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.hpp
@@ -9,17 +9,18 @@ namespace mtd
 	{
 		std::unique_ptr<GpuBuffer> descriptorBuffer;
 		vk::DescriptorBufferInfo descriptorBufferInfo;
-		vk::DescriptorImageInfo descriptorImageInfo;
+		std::vector<vk::DescriptorImageInfo> descriptorImagesInfo;
 	};
 
 	// Handles the data to be sent to the GPU through descriptors
 	class DescriptorSetHandler
 	{
 		public:
-			DescriptorSetHandler
-			(
-				const vk::Device& device,
-				const std::vector<vk::DescriptorSetLayoutBinding>& setLayoutBindings
+		DescriptorSetHandler
+		(
+			const vk::Device& device,
+			const std::vector<vk::DescriptorSetLayoutBinding>& setLayoutBindings,
+			const vk::DescriptorSetLayoutBindingFlagsCreateInfo* pFlags = nullptr
 			);
 			~DescriptorSetHandler();
 
@@ -31,6 +32,7 @@ namespace mtd
 			// Getters
 			const vk::DescriptorSetLayout& getLayout() const { return descriptorSetLayout; }
 			uint32_t getSetCount() const { return static_cast<uint32_t>(descriptorSets.size()); }
+			uint32_t getBindingCount() const { return static_cast<uint32_t>(descriptorTypes.size()); }
 			std::vector<vk::DescriptorSet>& getSets() { return descriptorSets; }
 			vk::DescriptorSet& getSet(uint32_t swappableSet) { return descriptorSets[swappableSet]; }
 			const vk::DescriptorSet& getSet(uint32_t swappableSet) const { return descriptorSets[swappableSet]; }
@@ -54,6 +56,13 @@ namespace mtd
 				uint32_t swappableSetIndex,
 				uint32_t binding,
 				const vk::DescriptorImageInfo& descriptorImageInfo
+			);
+			// Creates the resources for a vector of images descriptor
+			void createImagesDescriptorResources
+			(
+				uint32_t swappableSetIndex,
+				uint32_t binding,
+				std::vector<vk::DescriptorImageInfo>& descriptorImagesInfo
 			);
 			// Assigns an external GPU buffer as a descriptor
 			void assignExternalResourcesToDescriptor
@@ -88,6 +97,10 @@ namespace mtd
 			const vk::Device& device;
 
 			// Creates a descriptor set layout
-			void createDescriptorSetLayout(const std::vector<vk::DescriptorSetLayoutBinding>& bindings);
+			void createDescriptorSetLayout
+			(
+				const std::vector<vk::DescriptorSetLayoutBinding>& bindings,
+				const vk::DescriptorSetLayoutBindingFlagsCreateInfo* pFlags
+			);
 	};
 }

--- a/Engine/src/Vulkan/Device/PhysicalDevice.cpp
+++ b/Engine/src/Vulkan/Device/PhysicalDevice.cpp
@@ -38,12 +38,13 @@ mtd::PhysicalDevice::PhysicalDevice(const vk::Instance& vulkanInstance) : physic
 // Verifies if the hardware supports ray tracing
 bool mtd::PhysicalDevice::isRayTracingCompatible() const
 {
-	constexpr std::array<const char*, 4> rayTracingExtensions =
+	constexpr std::array<const char*, 5> rayTracingExtensions =
 	{
 		vk::KHRRayTracingPipelineExtensionName,
 		vk::KHRAccelerationStructureExtensionName,
 		vk::KHRDeferredHostOperationsExtensionName,
-		vk::KHRBufferDeviceAddressExtensionName
+		vk::KHRBufferDeviceAddressExtensionName,
+		vk::EXTDescriptorIndexingExtensionName
 	};
 	const std::vector<vk::ExtensionProperties> availableExtensions =
 		physicalDevice.enumerateDeviceExtensionProperties();

--- a/Engine/src/Vulkan/Image/Texture.hpp
+++ b/Engine/src/Vulkan/Image/Texture.hpp
@@ -11,6 +11,7 @@ namespace mtd
 	class Texture
 	{
 		public:
+			Texture(const Device& mtdDevice, const char* fileName);
 			Texture
 			(
 				const Device& mtdDevice,
@@ -27,6 +28,12 @@ namespace mtd
 
 			Texture(Texture&& other) noexcept;
 
+			// Getter
+			vk::DescriptorImageInfo getDescriptorImageInfo() const;
+
+			// Sends the texture data to the GPU
+			void loadToGpu(const Device& mtdDevice, const CommandHandler& commandHandler);
+
 		private:
 			// Texture data
 			int width, height, channels;
@@ -36,9 +43,7 @@ namespace mtd
 			Image image;
 
 			// Loads texture from file
-			void loadFromFile(const Device& mtdDevice, const CommandHandler& commandHandler, const char* fileName);
-			// Sends the texture data to the GPU
-			void loadToGpu(const Device& mtdDevice, const CommandHandler& commandHandler);
+			void loadFromFile(const Device& mtdDevice, const char* fileName);
 			// Configures the texture descriptor set
 			void createDescriptorResource
 			(

--- a/Engine/src/Vulkan/Image/Texture.hpp
+++ b/Engine/src/Vulkan/Image/Texture.hpp
@@ -41,6 +41,8 @@ namespace mtd
 
 			// Vulkan image resources
 			Image image;
+			// Indicates if the texture has failed to load properly
+			bool isPlaceholderTexture;
 
 			// Loads texture from file
 			void loadFromFile(const Device& mtdDevice, const char* fileName);

--- a/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
+++ b/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
@@ -124,16 +124,20 @@ void mtd::ObjMeshLoader::loadRayTracingMesh
 	std::vector<Vertex>& vertices,
 	std::vector<uint32_t>& indices,
 	std::vector<uint16_t>& materialIndices,
-	std::vector<Material>& meshMaterials,
-	const MaterialInfo& materialInfo
+	MaterialLump& materialLump
 )
 {
 	std::string objMeshPath{MTD_RESOURCES_PATH};
 	objMeshPath.append("meshes/");
 	objMeshPath.append(fileName);
 
+	std::vector<Material> materials;
 	std::unordered_map<std::string, uint32_t> materialIDs;
-	loadMaterials(objMeshPath, meshMaterials, materialIDs, materialInfo);
+	loadMaterials(objMeshPath, materials, materialIDs, materialLump.getMaterialInfo());
+
+	for(const Material& material: materials)
+		materialLump.addMaterial(material.getFloatAttributesData(), material.getFloatAttributesSize());
+	materials.clear();
 
 	std::string line;
 	std::vector<std::string> words;

--- a/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
+++ b/Engine/src/Vulkan/Mesh/ObjMeshLoader.cpp
@@ -136,7 +136,11 @@ void mtd::ObjMeshLoader::loadRayTracingMesh
 	loadMaterials(objMeshPath, materials, materialIDs, materialLump.getMaterialInfo());
 
 	for(const Material& material: materials)
-		materialLump.addMaterial(material.getFloatAttributesData(), material.getFloatAttributesSize());
+	{
+		std::vector<std::string> texturePaths;
+		material.fetchTexturePaths(texturePaths);
+		materialLump.addMaterial(material.getFloatAttributesData(), material.getFloatAttributesSize(), texturePaths);
+	}
 	materials.clear();
 
 	std::string line;

--- a/Engine/src/Vulkan/Mesh/ObjMeshLoader.hpp
+++ b/Engine/src/Vulkan/Mesh/ObjMeshLoader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../Material/Material.hpp"
+#include "../../Material/MaterialLump.hpp"
 
 // Responsible for loading Wavefront .obj files
 namespace mtd::ObjMeshLoader
@@ -32,7 +33,6 @@ namespace mtd::ObjMeshLoader
 		std::vector<Vertex>& vertices,
 		std::vector<uint32_t>& indices,
 		std::vector<uint16_t>& materialIndices,
-		std::vector<Material>& meshMaterials,
-		const MaterialInfo& materialInfo
+		MaterialLump& materialLump
 	);
 }

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMesh.cpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMesh.cpp
@@ -9,11 +9,13 @@ mtd::RayTracingMesh::RayTracingMesh
 	uint32_t index,
 	const char* id,
 	const char* fileName,
-	const MaterialInfo& materialInfo,
+	MaterialLump& materialLump,
 	const std::vector<Mat4x4>& preTransforms
-) : Mesh{device, index, id, preTransforms, 1}
+) : Mesh{device, index, id, preTransforms, 1}, materialCount{0U}
 {
-	ObjMeshLoader::loadRayTracingMesh(fileName, vertices, indices, materialIndices, materials, materialInfo);
+	uint32_t materialOffset = materialLump.getMaterialCount();
+	ObjMeshLoader::loadRayTracingMesh(fileName, vertices, indices, materialIndices, materialLump);
+	materialCount = materialLump.getMaterialCount() - materialOffset;
 }
 
 mtd::RayTracingMesh::RayTracingMesh(RayTracingMesh&& other) noexcept
@@ -21,34 +23,8 @@ mtd::RayTracingMesh::RayTracingMesh(RayTracingMesh&& other) noexcept
 	vertices{std::move(other.vertices)},
 	indices{std::move(other.indices)},
 	materialIndices{std::move(other.materialIndices)},
-	materials{std::move(other.materials)}
+	materialCount{other.materialCount}
 {}
-
-uint32_t mtd::RayTracingMesh::getTextureCount() const
-{
-	if(materials.empty()) return 0;
-	return static_cast<uint32_t>(materials[0].getTextureCount() * materials.size());
-}
-
-// Checks if the used material has float data attributes
-bool mtd::RayTracingMesh::hasMaterialFloatData() const
-{
-	if(materials.empty()) return false;
-	return materials[0].hasFloatData();
-}
-
-// Loads mesh materials
-void mtd::RayTracingMesh::loadMaterials
-(
-	const Device& device,
-	const CommandHandler& commandHandler,
-	DescriptorSetHandler& descriptorSetHandler,
-	uint32_t initialMaterialIndex
-)
-{
-	for(uint32_t i = 0; i < materials.size(); i++)
-		materials[i].loadMaterial(device, commandHandler, descriptorSetHandler, 0, 4);
-}
 
 // Deletes all mesh data on this object
 void mtd::RayTracingMesh::clearMeshData()

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMesh.hpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMesh.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../Mesh.hpp"
-#include "../../../Material/Material.hpp"
+#include "../../../Material/MaterialLump.hpp"
 
 namespace mtd
 {
@@ -15,7 +15,7 @@ namespace mtd
 				uint32_t index,
 				const char* id,
 				const char* fileName,
-				const MaterialInfo& materialInfo,
+				MaterialLump& materialLump,
 				const std::vector<Mat4x4>& preTransforms
 			);
 			~RayTracingMesh() = default;
@@ -26,20 +26,7 @@ namespace mtd
 			const std::vector<Vertex>& getVertices() const { return vertices; }
 			const std::vector<uint32_t>& getIndices() const { return indices; }
 			const std::vector<uint16_t>& getMaterialIndices() const { return materialIndices; }
-			uint32_t getMaterialCount() const { return static_cast<uint32_t>(materials.size()); }
-			uint32_t getTextureCount() const;
-
-			// Checks if the used material has float data attributes
-			bool hasMaterialFloatData() const;
-
-			// Loads mesh materials
-			void loadMaterials
-			(
-				const Device& device,
-				const CommandHandler& commandHandler,
-				DescriptorSetHandler& descriptorSetHandler,
-				uint32_t initialMaterialIndex
-			);
+			uint32_t getMaterialCount() const { return materialCount; }
 
 			// Deletes all mesh data on this object
 			void clearMeshData();
@@ -50,7 +37,7 @@ namespace mtd
 			std::vector<uint32_t> indices;
 			std::vector<uint16_t> materialIndices;
 
-			// Mesh materials
-			std::vector<Material> materials;
+			// Mesh material count
+			uint32_t materialCount;
 	};
 }

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
@@ -24,7 +24,9 @@ void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptor
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 1, vertexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 2, indexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 3, materialIndexBuffer);
-	materialLump.assignBufferToDescriptor(meshDescriptorSetHandler, 0, 4);
+	materialLump.assignFloatDataBufferToDescriptor(meshDescriptorSetHandler, 0, 4);
+	if(meshDescriptorSetHandler.getBindingCount() == 6)
+		materialLump.assignTexturesToDescriptor(meshDescriptorSetHandler, 0, 5);
 }
 
 // Creates a new ray tracing mesh

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
@@ -1,49 +1,22 @@
 #include <pch.hpp>
 #include "RayTracingMeshManager.hpp"
 
-mtd::RayTracingMeshManager::RayTracingMeshManager(const Device& device)
+mtd::RayTracingMeshManager::RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo)
 	: BaseMeshManager{device},
 	currentIndexOffset{0},
 	currentMaterialIndexOffset{0},
 	vertexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
 	indexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
-	materialIndexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal}
+	materialIndexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
+	materialLump{device, materialInfo}
 {}
-
-uint32_t mtd::RayTracingMeshManager::getMaterialCount() const
-{
-	uint32_t totalMaterialCount = 0;
-	for(const RayTracingMesh& mesh: meshes)
-		totalMaterialCount += mesh.getMaterialCount();
-	return totalMaterialCount;
-}
-
-uint32_t mtd::RayTracingMeshManager::getTextureCount() const
-{
-	uint32_t totalTextureCount = 0;
-	for(const RayTracingMesh& mesh: meshes)
-		totalTextureCount += mesh.getTextureCount();
-	return totalTextureCount;
-}
-
-// Checks if the material type for the stored meshes has float data
-bool mtd::RayTracingMeshManager::hasMaterialFloatData() const
-{
-	if(meshes.empty()) return false;
-	return meshes[0].hasMaterialFloatData();
-}
 
 // Loads the materials and groups the meshes into a lump, then passes the data to the GPU
 void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptorSetHandler)
 {
-	uint32_t currentMaterialCount = 0;
 	for(uint32_t i = 0; i < meshes.size(); i++)
 	{
 		loadMeshToLump(meshes[i]);
-
-		meshes[i].loadMaterials(device, commandHandler, meshDescriptorSetHandler, currentMaterialCount);
-		currentMaterialCount += meshes[i].getMaterialCount();
-
 		meshIndexMap[meshes[i].getModelID()] = i;
 	}
 	loadMeshesToGPU(commandHandler);
@@ -51,18 +24,17 @@ void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptor
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 1, vertexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 2, indexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 3, materialIndexBuffer);
+	materialLump.assignBufferToDescriptor(meshDescriptorSetHandler, 0, 4);
 }
 
-// Binds vertex and index buffers
-void mtd::RayTracingMeshManager::bindBuffers(const vk::CommandBuffer& commandBuffer) const
-{}
-
-// Draws the meshes using a rasterization pipeline
-void mtd::RayTracingMeshManager::drawMesh
+// Creates a new ray tracing mesh
+void mtd::RayTracingMeshManager::createNewMesh
 (
-	const vk::CommandBuffer& commandBuffer, const GraphicsPipeline& graphicsPipeline
-) const
-{}
+	uint32_t index, const char* id, const char* file, const std::vector<Mat4x4>& preTransforms
+)
+{
+	meshes.emplace_back(device, index, id, file, materialLump, preTransforms);
+}
 
 // Draws the meshes using a ray tracing pipeline
 void mtd::RayTracingMeshManager::rayTraceMesh
@@ -98,12 +70,15 @@ void mtd::RayTracingMeshManager::loadMeshToLump(RayTracingMesh& mesh)
 }
 
 // Loads the lumps into the VRAM and clears them
-void mtd::RayTracingMeshManager::loadMeshesToGPU(const CommandHandler& commandHandler)
+void mtd::RayTracingMeshManager::loadMeshesToGPU(const CommandHandler& traceRaysCommandHandler)
 {
-	vertexBuffer.createDeviceLocal(commandHandler, sizeof(Vertex) * vertexLump.size(), vertexLump.data());
-	indexBuffer.createDeviceLocal(commandHandler, sizeof(uint32_t) * indexLump.size(), indexLump.data());
-	materialIndexBuffer
-		.createDeviceLocal(commandHandler, sizeof(uint16_t) * materialIndexLump.size(), materialIndexLump.data());
+	vertexBuffer.createDeviceLocal(traceRaysCommandHandler, sizeof(Vertex) * vertexLump.size(), vertexLump.data());
+	indexBuffer.createDeviceLocal(traceRaysCommandHandler, sizeof(uint32_t) * indexLump.size(), indexLump.data());
+	materialIndexBuffer.createDeviceLocal
+	(
+		traceRaysCommandHandler, sizeof(uint16_t) * materialIndexLump.size(), materialIndexLump.data()
+	);
+	materialLump.loadMaterialsToGPU(traceRaysCommandHandler);
 
 	for(RayTracingMesh& mesh: meshes)
 		mesh.createInstanceBuffer();

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
@@ -9,28 +9,34 @@ namespace mtd
 	class RayTracingMeshManager : public BaseMeshManager<RayTracingMesh>
 	{
 		public:
-			RayTracingMeshManager(const Device& device);
+			RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo);
 			~RayTracingMeshManager() = default;
 
 			// Getters
-			virtual uint32_t getMaterialCount() const override;
-			virtual uint32_t getTextureCount() const override;
+			virtual uint32_t getMaterialCount() const override { return materialLump.getMaterialCount(); }
+			virtual uint32_t getTextureCount() const override { return materialLump.getTextureCount(); }
 			const GpuBuffer& getVertexBuffer() const { return vertexBuffer; }
 			const GpuBuffer& getIndexBuffer() const { return indexBuffer; }
 
 			// Checks if the material type for the stored meshes has float data
-			virtual bool hasMaterialFloatData() const override;
+			virtual bool hasMaterialFloatData() const override { return materialLump.hasFloatData(); }
 
 			// Loads the materials and groups the meshes into a lump, then passes the data to the GPU
 			virtual void loadMeshes(DescriptorSetHandler& meshDescriptorSetHandler) override;
 
+			// Creates a new ray tracing mesh
+			void createNewMesh
+			(
+				uint32_t index, const char* id, const char* file, const std::vector<Mat4x4>& preTransforms
+			);
+
 			// Binds vertex and index buffers
-			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override;
+			virtual void bindBuffers(const vk::CommandBuffer& commandBuffer) const override {}
 			// Draws the meshes using a rasterization pipeline
 			virtual void drawMesh
 			(
 				const vk::CommandBuffer& commandBuffer, const GraphicsPipeline& graphicsPipeline
-			) const override;
+			) const override {}
 
 			// Draws the meshes using a ray tracing pipeline
 			void rayTraceMesh
@@ -52,6 +58,9 @@ namespace mtd
 			// Material index buffer data, with the material ID for each triangle
 			std::vector<uint16_t> materialIndexLump;
 
+			// Mesh manager materials
+			MaterialLump materialLump;
+
 			// Index offset counters
 			uint32_t currentIndexOffset;
 			uint32_t currentMaterialIndexOffset;
@@ -59,6 +68,6 @@ namespace mtd
 			// Stores a mesh in the lump of data
 			void loadMeshToLump(RayTracingMesh& mesh);
 			// Loads the lumps into the VRAM and clears them
-			void loadMeshesToGPU(const CommandHandler& commandHandler);
+			void loadMeshesToGPU(const CommandHandler& traceRaysCommandHandler);
 	};
 }

--- a/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
+++ b/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
@@ -145,55 +145,21 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 {
 	descriptorSetHandlers.reserve(info.descriptorSetInfo.size() == 0 ? 1 : 2);
 
-	bool hasFloatData = !info.materialFloatDataTypes.empty();
-	bool hasTextures = !info.materialTextureTypes.empty();
-
-	uint32_t materialBindingCount = static_cast<uint32_t>(hasFloatData) + static_cast<uint32_t>(hasTextures);
-
-	std::vector<vk::DescriptorSetLayoutBinding> layoutBindings(4 + materialBindingCount);
+	const uint32_t bindingCount = 5U;
+	std::vector<vk::DescriptorSetLayoutBinding> layoutBindings(bindingCount);
 	layoutBindings[0].binding = 0;
 	layoutBindings[0].descriptorType = vk::DescriptorType::eStorageImage;
 	layoutBindings[0].descriptorCount = 1;
 	layoutBindings[0].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eMissKHR;
 	layoutBindings[0].pImmutableSamplers = nullptr;
 
-	layoutBindings[1].binding = 1;
-	layoutBindings[1].descriptorType = vk::DescriptorType::eStorageBuffer;
-	layoutBindings[1].descriptorCount = 1;
-	layoutBindings[1].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
-	layoutBindings[1].pImmutableSamplers = nullptr;
-
-	layoutBindings[2].binding = 2;
-	layoutBindings[2].descriptorType = vk::DescriptorType::eStorageBuffer;
-	layoutBindings[2].descriptorCount = 1;
-	layoutBindings[2].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
-	layoutBindings[2].pImmutableSamplers = nullptr;
-
-	layoutBindings[3].binding = 3;
-	layoutBindings[3].descriptorType = vk::DescriptorType::eStorageBuffer;
-	layoutBindings[3].descriptorCount = 1;
-	layoutBindings[3].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
-	layoutBindings[3].pImmutableSamplers = nullptr;
-
-	uint32_t bindingIndex = 4;
-
-	if(hasFloatData)
+	for(uint32_t i = 1; i < bindingCount; i++)
 	{
-		layoutBindings[bindingIndex].binding = bindingIndex;
-		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eUniformBuffer;
-		layoutBindings[bindingIndex].descriptorCount = 1;
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
-		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
-
-		bindingIndex++;
-	}
-	if(hasTextures)
-	{
-		layoutBindings[bindingIndex].binding = bindingIndex;
-		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eCombinedImageSampler;
-		layoutBindings[bindingIndex].descriptorCount = static_cast<uint32_t>(info.materialTextureTypes.size());
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
-		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
+		layoutBindings[i].binding = i;
+		layoutBindings[i].descriptorType = vk::DescriptorType::eStorageBuffer;
+		layoutBindings[i].descriptorCount = 1;
+		layoutBindings[i].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
+		layoutBindings[i].pImmutableSamplers = nullptr;
 	}
 
 	descriptorSetHandlers.emplace_back(device, layoutBindings);


### PR DESCRIPTION
A material system for the ray tracing based rendering has been created, allowing the engine to group all material data in only two descriptors, making it possible to render the entire scene in a single trace rays call.