### PR TITLE
Add ray tracing shader modules

### DIFF
--- a/Engine/include/meltdown/structs.hpp
+++ b/Engine/include/meltdown/structs.hpp
@@ -131,6 +131,8 @@ namespace mtd
 	{
 		/* @brief File path to the ray generation shader, from the shaders folder. */
 		std::string rayGenShaderPath;
+		/* @brief File path to the closest hit shader, from the shaders folder. */
+		std::string closestHitShaderPath;
 		/* @brief File path to the miss shader, from the shaders folder. */
 		std::string missShaderPath;
 		/* @brief Ratio between the storage image and window resolution. Use negative values for a fixed resolution. */

--- a/Engine/src/Scene/SceneLoader.cpp
+++ b/Engine/src/Scene/SceneLoader.cpp
@@ -295,6 +295,7 @@ void loadRayTracingPipeline
 		{
 			{rtPipelineJson["name"], std::move(descriptorInfos)},
 			rtPipelineJson["ray-gen-shader"],
+			rtPipelineJson["closest-hit-shader"],
 			rtPipelineJson["miss-shader"],
 			{
 				rtPipelineJson.value("resolution-ratio-horizontal", -1.0f),

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rchit
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rchit
@@ -1,9 +1,116 @@
 #version 460
 #extension GL_EXT_ray_tracing : enable
+#extension GL_EXT_shader_16bit_storage : enable
 
-layout(location = 0) rayPayloadInEXT vec4 payload;
+struct Payload
+{
+	vec3 light;
+	vec3 throughput;
+	uint recursionDepth;
+	uint randomState;
+};
+
+struct Vertex
+{
+	vec3 position;
+	vec2 textureUV;
+};
+
+struct MaterialFloatAttributes
+{
+	vec4 diffuse;
+};
+
+
+const float PI = 3.14159265359f;
+const float TWO_PI = 6.28318530718f;
+
+
+hitAttributeEXT vec2 attributes;
+
+layout(location = 0) rayPayloadInEXT Payload payload;
+
+layout(push_constant) uniform PushConstant
+{
+	uint maxRecursionDepth;
+	uint samplesPerPixel;
+	uint accumulatedFrames;
+	uint randomSeed;
+} renderingInfo;
+
+layout(set = 1, binding = 0) uniform accelerationStructureEXT accelerationStructure;
+layout(set = 1, binding = 2) buffer VertexBuffer
+{
+	Vertex vertices[];
+};
+layout(set = 1, binding = 3) buffer IndexBuffer
+{
+	uint indices[];
+};
+layout(set = 1, binding = 4) buffer MaterialIndexBuffer
+{
+	uint16_t materialIDs[];
+};
+layout(set = 1, binding = 5) buffer MaterialsFloatBuffer
+{
+	MaterialFloatAttributes materialFloatAttributes[];
+};
+
+
+uint pcgHash(uint inputValue)
+{
+	uint state = inputValue * 0x2C9277B5U + 0xAC564B05U;
+	uint word = ((state >> ((state >> 28U) + 4U)) ^ state) * 0x108EF2D9U;
+	return (word >> 22U) ^ word;
+}
+
+float randomFloat(inout uint seed)
+{
+	seed = pcgHash(seed);
+	return float(seed) / float(0xFFFFFFFFU);
+}
+
+vec3 unitSphereSample(inout uint randomState)
+{
+	float theta = randomFloat(randomState) * TWO_PI;
+	float phi = (randomFloat(randomState) - 0.5f) * PI;
+
+	return vec3(cos(phi) * cos(theta), -sin(phi), cos(phi) * sin(theta));
+}
 
 void main()
 {
-	payload = vec4(1.0f, 0.5f, 0.0f, 1.0f);
+	payload.recursionDepth++;
+
+	vec3 v0 = vertices[indices[3 * gl_PrimitiveID]].position;
+	vec3 v1 = vertices[indices[3 * gl_PrimitiveID + 1]].position;
+	vec3 v2 = vertices[indices[3 * gl_PrimitiveID + 2]].position;
+	vec3 e1 = v1 - v0;
+	vec3 e2 = v2 - v0;
+
+	vec3 normal = cross(e1, e2);
+	normal = normalize((gl_HitKindEXT == gl_HitKindFrontFacingTriangleEXT) ? normal : -normal);
+	vec3 hitPoint = v0 + attributes.x * e1 + attributes.y * e2;
+
+	vec3 newDirection = unitSphereSample(payload.randomState);
+	newDirection = normalize(newDirection + normal);
+
+	MaterialFloatAttributes material = materialFloatAttributes[uint(materialIDs[gl_PrimitiveID])];
+	float emissivity = 0.0f;
+
+	payload.light += emissivity * payload.throughput;
+	payload.throughput *= material.diffuse.xyz;
+
+	if(payload.recursionDepth >= renderingInfo.maxRecursionDepth) return;
+	traceRayEXT
+	(
+		accelerationStructure,
+		gl_RayFlagsOpaqueEXT,
+		0xFF,
+		0, 0,
+		0,
+		hitPoint, 0.001f,
+		newDirection, 10000.0f,
+		0
+	);
 }

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rchit
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rchit
@@ -1,0 +1,9 @@
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+layout(location = 0) rayPayloadInEXT vec4 payload;
+
+void main()
+{
+	payload = vec4(1.0f, 0.5f, 0.0f, 1.0f);
+}

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rgen
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rgen
@@ -1,17 +1,13 @@
 #version 460
 #extension GL_EXT_ray_tracing : enable
-#extension GL_EXT_shader_16bit_storage : enable
 
-struct Vertex
+struct Ray
 {
-	vec3 position;
-	vec2 textureUV;
+	vec3 origin;
+	vec3 direction;
 };
 
-struct MaterialFloatAttributes
-{
-	vec4 diffuse;
-};
+layout(location = 0) rayPayloadEXT vec4 payload;
 
 layout(set = 0, binding = 0) uniform CameraMatrices
 {
@@ -20,54 +16,8 @@ layout(set = 0, binding = 0) uniform CameraMatrices
 	mat4 projectionView;
 } camera;
 
-layout(set = 1, binding = 0, rgba8) uniform image2D storageImage;
-layout(set = 1, binding = 1) buffer VertexBuffer
-{
-	Vertex vertices[];
-};
-layout(set = 1, binding = 2) buffer IndexBuffer
-{
-	uint indices[];
-};
-layout(set = 1, binding = 3) buffer MaterialIndexBuffer
-{
-	uint16_t materialIDs[];
-};
-layout(set = 1, binding = 4) buffer MaterialsFloatBuffer
-{
-	MaterialFloatAttributes materialFloatAttributes[];
-};
-
-struct Ray
-{
-	vec3 origin;
-	vec3 direction;
-};
-
-bool intersectTriangle(Ray ray, Vertex v0, Vertex v1, Vertex v2, out float hitDistance)
-{
-	vec3 edge1 = v1.position - v0.position;
-	vec3 edge2 = v2.position - v0.position;
-
-	vec3 hVector = cross(ray.direction, edge2);
-	float det = dot(edge1, hVector);
-	if(abs(det) < 1e-6) return false;
-
-	float invDet = 1.0f / det;
-	vec3 relativeRayOrigin = ray.origin - v0.position;
-	float u = invDet * dot(relativeRayOrigin, hVector);
-	if(u < -1e-6 || u - 1.0f > 1e-6) return false;
-
-	vec3 qVector = cross(relativeRayOrigin, edge1);
-	float v = invDet * dot(ray.direction, qVector);
-	if(v < -1e-6 || u + v - 1.0f > 1e-6) return false;
-
-	float t = invDet * dot(edge2, qVector);
-	if(t < 1e-6) return false;
-
-	hitDistance = t;
-	return true;
-}
+layout(set = 1, binding = 0) uniform accelerationStructureEXT accelerationStructure;
+layout(set = 1, binding = 1, rgba8) uniform image2D storageImage;
 
 void main()
 {
@@ -81,23 +31,17 @@ void main()
 	ray.origin = invView[3].xyz;
 	ray.direction = normalize((invView * (farPoint / farPoint.w)).xyz - ray.origin);
 
-	vec4 color = vec4(0.0f, 0.0f, 0.0f, 1.0f);
-	float closestHit = 1e9;
+	traceRayEXT
+	(
+		accelerationStructure,
+		gl_RayFlagsOpaqueEXT,
+		0xFF,
+		0, 0,
+		0,
+		ray.origin, 0.001f,
+		ray.direction, 10000.0f,
+		0
+	);
 
-	int triangleCount = indices.length() / 3;
-	for(int i = 0; i < triangleCount; i++)
-	{
-		Vertex v0 = vertices[indices[3 * i]];
-		Vertex v1 = vertices[indices[3 * i + 1]];
-		Vertex v2 = vertices[indices[3 * i + 2]];
-
-		float hitDistance = 1e10;
-		if(intersectTriangle(ray, v0, v1, v2, hitDistance) && hitDistance < closestHit)
-		{
-			closestHit = hitDistance;
-			color = materialFloatAttributes[uint(materialIDs[i])].diffuse;
-		}
-	}
-
-	imageStore(storageImage, ivec2(pixelCoord), color);
+	imageStore(storageImage, ivec2(pixelCoord), payload);
 }

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rgen
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rgen
@@ -7,7 +7,24 @@ struct Ray
 	vec3 direction;
 };
 
-layout(location = 0) rayPayloadEXT vec4 payload;
+struct Payload
+{
+	vec3 light;
+	vec3 throughput;
+	uint recursionDepth;
+	uint randomState;
+};
+
+
+layout(location = 0) rayPayloadEXT Payload payload;
+
+layout(push_constant) uniform PushConstant
+{
+	uint maxRecursionDepth;
+	uint samplesPerPixel;
+	uint accumulatedFrames;
+	uint randomSeed;
+} renderingInfo;
 
 layout(set = 0, binding = 0) uniform CameraMatrices
 {
@@ -19,29 +36,47 @@ layout(set = 0, binding = 0) uniform CameraMatrices
 layout(set = 1, binding = 0) uniform accelerationStructureEXT accelerationStructure;
 layout(set = 1, binding = 1, rgba8) uniform image2D storageImage;
 
+
 void main()
 {
 	vec2 pixelCoord = gl_LaunchIDEXT.xy;
 	vec2 uv = 2.0f * (pixelCoord / gl_LaunchSizeEXT.xy) - 1.0f;
 
-	mat4 invView = inverse(camera.view);
+	mat4 inverseView = inverse(camera.view);
 	vec4 farPoint = inverse(camera.projection) * vec4(uv, 1.0f, 1.0f);
 
 	Ray ray;
-	ray.origin = invView[3].xyz;
-	ray.direction = normalize((invView * (farPoint / farPoint.w)).xyz - ray.origin);
+	ray.origin = inverseView[3].xyz;
+	ray.direction = normalize((inverseView * (farPoint / farPoint.w)).xyz - ray.origin);
 
-	traceRayEXT
-	(
-		accelerationStructure,
-		gl_RayFlagsOpaqueEXT,
-		0xFF,
-		0, 0,
-		0,
-		ray.origin, 0.001f,
-		ray.direction, 10000.0f,
-		0
-	);
+	payload.randomState = renderingInfo.randomSeed + gl_LaunchIDEXT.y * gl_LaunchSizeEXT.x + gl_LaunchIDEXT.x;
 
-	imageStore(storageImage, ivec2(pixelCoord), payload);
+	vec3 accumulatedLight = vec3(0.0f);
+	for(uint sampleIndex = 0; sampleIndex < renderingInfo.samplesPerPixel; sampleIndex++)
+	{
+		payload.light = vec3(0.0f);
+		payload.throughput = vec3(1.0f);
+		payload.recursionDepth = 0;
+
+		traceRayEXT
+		(
+			accelerationStructure,
+			gl_RayFlagsOpaqueEXT,
+			0xFF,
+			0, 0,
+			0,
+			ray.origin, 0.001f,
+			ray.direction, 10000.0f,
+			0
+		);
+
+		accumulatedLight += payload.light;
+	}
+	accumulatedLight /= renderingInfo.samplesPerPixel;
+
+	uint frameCount = min(renderingInfo.accumulatedFrames, 2U);
+	vec3 previousColor = imageLoad(storageImage, ivec2(pixelCoord)).xyz;
+	accumulatedLight = (accumulatedLight + frameCount * previousColor) / (frameCount + 1);
+
+	imageStore(storageImage, ivec2(pixelCoord), vec4(accumulatedLight, 1.0f));
 }

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rmiss
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rmiss
@@ -1,93 +1,22 @@
 #version 460
 #extension GL_EXT_ray_tracing : enable
-#extension GL_EXT_shader_16bit_storage : enable
 
-struct Ray
+struct Payload
 {
-	vec3 origin;
-	vec3 direction;
+	vec3 light;
+	vec3 throughput;
+	uint recursionDepth;
+	uint randomState;
 };
 
-struct Vertex
-{
-	vec3 position;
-	vec2 textureUV;
-};
 
-struct MaterialFloatAttributes
-{
-	vec4 diffuse;
-};
+layout(location = 0) rayPayloadInEXT Payload payload;
 
-layout(location = 0) rayPayloadInEXT vec4 payload;
-
-layout(set = 1, binding = 2) buffer VertexBuffer
-{
-	Vertex vertices[];
-};
-layout(set = 1, binding = 3) buffer IndexBuffer
-{
-	uint indices[];
-};
-layout(set = 1, binding = 4) buffer MaterialIndexBuffer
-{
-	uint16_t materialIDs[];
-};
-layout(set = 1, binding = 5) buffer MaterialsFloatBuffer
-{
-	MaterialFloatAttributes materialFloatAttributes[];
-};
-
-bool intersectTriangle(Ray ray, Vertex v0, Vertex v1, Vertex v2, out float hitDistance)
-{
-	vec3 edge1 = v1.position - v0.position;
-	vec3 edge2 = v2.position - v0.position;
-
-	vec3 hVector = cross(ray.direction, edge2);
-	float det = dot(edge1, hVector);
-	if(abs(det) < 1e-6) return false;
-
-	float invDet = 1.0f / det;
-	vec3 relativeRayOrigin = ray.origin - v0.position;
-	float u = invDet * dot(relativeRayOrigin, hVector);
-	if(u < -1e-6 || u - 1.0f > 1e-6) return false;
-
-	vec3 qVector = cross(relativeRayOrigin, edge1);
-	float v = invDet * dot(ray.direction, qVector);
-	if(v < -1e-6 || u + v - 1.0f > 1e-6) return false;
-
-	float t = invDet * dot(edge2, qVector);
-	if(t < 1e-6) return false;
-
-	hitDistance = t;
-	return true;
-}
 
 void main()
 {
-	Ray ray;
-	ray.origin = gl_WorldRayOriginEXT;
-	ray.direction = gl_WorldRayDirectionEXT;
-
-	float backgroundColor = 0.05f * (1.2f + dot(ray.direction.xyz, vec3(0.0f, -1.0f, 0.0f)));
-
-	vec4 color = vec4(vec3(backgroundColor), 1.0f);
-	float closestHit = 1e9;
-
-	int triangleCount = indices.length() / 3;
-	for(int i = 0; i < triangleCount; i++)
-	{
-		Vertex v0 = vertices[indices[3 * i]];
-		Vertex v1 = vertices[indices[3 * i + 1]];
-		Vertex v2 = vertices[indices[3 * i + 2]];
-
-		float hitDistance = 1e10;
-		if(intersectTriangle(ray, v0, v1, v2, hitDistance) && hitDistance < closestHit)
-		{
-			closestHit = hitDistance;
-			color = materialFloatAttributes[uint(materialIDs[i])].diffuse;
-		}
-	}
-
-	payload = color;
+	if(payload.recursionDepth > 0)
+		payload.light += payload.throughput * vec3(1.0f);
+	else
+		payload.light += vec3(0.3f, 0.6f, 1.0f);
 }

--- a/Engine/src/Shaders/RayTracing/ray-tracing.rmiss
+++ b/Engine/src/Shaders/RayTracing/ray-tracing.rmiss
@@ -1,11 +1,93 @@
 #version 460
 #extension GL_EXT_ray_tracing : enable
+#extension GL_EXT_shader_16bit_storage : enable
 
-layout(set = 1, binding = 0, rgba8) uniform image2D storageImage;
+struct Ray
+{
+	vec3 origin;
+	vec3 direction;
+};
+
+struct Vertex
+{
+	vec3 position;
+	vec2 textureUV;
+};
+
+struct MaterialFloatAttributes
+{
+	vec4 diffuse;
+};
+
+layout(location = 0) rayPayloadInEXT vec4 payload;
+
+layout(set = 1, binding = 2) buffer VertexBuffer
+{
+	Vertex vertices[];
+};
+layout(set = 1, binding = 3) buffer IndexBuffer
+{
+	uint indices[];
+};
+layout(set = 1, binding = 4) buffer MaterialIndexBuffer
+{
+	uint16_t materialIDs[];
+};
+layout(set = 1, binding = 5) buffer MaterialsFloatBuffer
+{
+	MaterialFloatAttributes materialFloatAttributes[];
+};
+
+bool intersectTriangle(Ray ray, Vertex v0, Vertex v1, Vertex v2, out float hitDistance)
+{
+	vec3 edge1 = v1.position - v0.position;
+	vec3 edge2 = v2.position - v0.position;
+
+	vec3 hVector = cross(ray.direction, edge2);
+	float det = dot(edge1, hVector);
+	if(abs(det) < 1e-6) return false;
+
+	float invDet = 1.0f / det;
+	vec3 relativeRayOrigin = ray.origin - v0.position;
+	float u = invDet * dot(relativeRayOrigin, hVector);
+	if(u < -1e-6 || u - 1.0f > 1e-6) return false;
+
+	vec3 qVector = cross(relativeRayOrigin, edge1);
+	float v = invDet * dot(ray.direction, qVector);
+	if(v < -1e-6 || u + v - 1.0f > 1e-6) return false;
+
+	float t = invDet * dot(edge2, qVector);
+	if(t < 1e-6) return false;
+
+	hitDistance = t;
+	return true;
+}
 
 void main()
 {
-	ivec2 pixelCoord = ivec2(gl_LaunchIDEXT.xy);
+	Ray ray;
+	ray.origin = gl_WorldRayOriginEXT;
+	ray.direction = gl_WorldRayDirectionEXT;
 
-	imageStore(storageImage, pixelCoord, vec4(1.0f, 0.0f, 1.0f, 1.0f));
+	float backgroundColor = 0.05f * (1.2f + dot(ray.direction.xyz, vec3(0.0f, -1.0f, 0.0f)));
+
+	vec4 color = vec4(vec3(backgroundColor), 1.0f);
+	float closestHit = 1e9;
+
+	int triangleCount = indices.length() / 3;
+	for(int i = 0; i < triangleCount; i++)
+	{
+		Vertex v0 = vertices[indices[3 * i]];
+		Vertex v1 = vertices[indices[3 * i + 1]];
+		Vertex v2 = vertices[indices[3 * i + 2]];
+
+		float hitDistance = 1e10;
+		if(intersectTriangle(ray, v0, v1, v2, hitDistance) && hitDistance < closestHit)
+		{
+			closestHit = hitDistance;
+			color = materialFloatAttributes[uint(materialIDs[i])].diffuse;
+		}
+	}
+
+	payload = color;
 }

--- a/Engine/src/Utils/EngineStructs.hpp
+++ b/Engine/src/Utils/EngineStructs.hpp
@@ -102,4 +102,13 @@ namespace mtd
 		const vk::Framebuffer* framebuffer;
 		const SynchronizationBundle* syncBundle;
 	};
+
+	// Ray tracing push constant struct
+	struct RayTracingRenderData
+	{
+		uint32_t maxRecursionDepth = 1U;
+		uint32_t samplesPerPixel = 1U;
+		uint32_t accumulatedFrames = 0U;
+		uint32_t randomSeed = 0U;
+	};
 }

--- a/Engine/src/Vulkan/AccelerationStructure/AccelerationStructure.cpp
+++ b/Engine/src/Vulkan/AccelerationStructure/AccelerationStructure.cpp
@@ -1,0 +1,178 @@
+#include <pch.hpp>
+#include "AccelerationStructure.hpp"
+
+#include "ScratchAccelerationStructure.hpp"
+#include "../../Utils/Logger.hpp"
+
+mtd::AccelerationStructure::AccelerationStructure(const Device& device)
+	: device{device},
+	accelerationStructure{nullptr},
+	asBuffer
+	{
+		device,
+		vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+		vk::MemoryPropertyFlagBits::eDeviceLocal
+	},
+	asType{vk::AccelerationStructureTypeKHR::eGeneric},
+	geometry{},
+	asBuildGeometryInfo{}
+{}
+
+mtd::AccelerationStructure::~AccelerationStructure()
+{
+	device.getDevice().destroyAccelerationStructureKHR(accelerationStructure, nullptr, device.getDLDI());
+}
+
+// Creates the Bottom Level Acceleration Structure (BLAS)
+void mtd::AccelerationStructure::createBLAS
+(
+	const CommandHandler& commandHandler,
+	vk::DeviceAddress vertexBufferAddress,
+	uint32_t vertexCount,
+	vk::DeviceAddress indexBufferAddress,
+	uint32_t triangleCount
+)
+{
+	assert
+	(
+		accelerationStructure == nullptr
+		&& "A BLAS cannot be created over and already initialized acceleration structure."
+	);
+
+	asType = vk::AccelerationStructureTypeKHR::eBottomLevel;
+
+	vk::AccelerationStructureGeometryTrianglesDataKHR asGeometryTrianglesData{};
+	asGeometryTrianglesData.vertexFormat = vk::Format::eR32G32B32Sfloat;
+	asGeometryTrianglesData.vertexData.deviceAddress = vertexBufferAddress;
+	asGeometryTrianglesData.vertexStride = sizeof(Vertex);
+	asGeometryTrianglesData.maxVertex = vertexCount;
+	asGeometryTrianglesData.indexType = vk::IndexType::eUint32;
+	asGeometryTrianglesData.indexData.deviceAddress = indexBufferAddress;
+	asGeometryTrianglesData.transformData.deviceAddress = 0;
+
+	geometry.geometryType = vk::GeometryTypeKHR::eTriangles;
+	geometry.geometry.triangles = asGeometryTrianglesData;
+	geometry.flags = vk::GeometryFlagBitsKHR::eOpaque;
+
+	createAS(commandHandler, triangleCount);
+}
+
+// Creates the Top Level Acceleration Structure (TLAS)
+void mtd::AccelerationStructure::createTLAS
+(
+	const CommandHandler& commandHandler, vk::DeviceAddress instanceBufferAddress
+)
+{
+	assert
+	(
+		accelerationStructure == nullptr
+		&& "A TLAS cannot be created over and already initialized acceleration structure."
+	);
+	
+	asType = vk::AccelerationStructureTypeKHR::eTopLevel;
+
+	vk::AccelerationStructureGeometryInstancesDataKHR tlasGeometryInstancesData{};
+	tlasGeometryInstancesData.arrayOfPointers = vk::False;
+	tlasGeometryInstancesData.data.deviceAddress = instanceBufferAddress;
+
+	geometry.geometryType = vk::GeometryTypeKHR::eInstances;
+	geometry.geometry.instances = tlasGeometryInstancesData;
+
+	createAS(commandHandler, 1U);
+}
+
+// Creates an instance buffer
+mtd::GpuBuffer mtd::AccelerationStructure::createInstanceBuffer() const
+{
+	assert
+	(
+		accelerationStructure != nullptr && asType == vk::AccelerationStructureTypeKHR::eBottomLevel
+		&& "The acceleration structure must be a bottom level type and needs to be created before the instance buffer."
+	);
+
+	vk::TransformMatrixKHR identityMatrix{};
+	identityMatrix.matrix[0][0] = 1.0f;
+	identityMatrix.matrix[1][1] = 1.0f;
+	identityMatrix.matrix[2][2] = 1.0f;
+
+	vk::AccelerationStructureInstanceKHR asInstance{};
+	asInstance.transform = identityMatrix;
+	asInstance.instanceCustomIndex = 0;
+	asInstance.mask = 0xFF;
+	asInstance.instanceShaderBindingTableRecordOffset = 0;
+	asInstance.flags = (VkGeometryInstanceFlagBitsKHR)vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable;
+	asInstance.accelerationStructureReference = asBuffer.getBufferAddress();
+
+	GpuBuffer instanceBuffer
+	{
+		device,
+		sizeof(vk::AccelerationStructureInstanceKHR),
+		vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR
+		| vk::BufferUsageFlagBits::eShaderDeviceAddress,
+		vk::MemoryPropertyFlagBits::eHostVisible
+	};
+	instanceBuffer.copyMemoryToBuffer(sizeof(vk::AccelerationStructureInstanceKHR), &asInstance);
+
+	return instanceBuffer;
+}
+
+// Handles the common creation logic for both BLAS and TLAS
+void mtd::AccelerationStructure::createAS(const CommandHandler& commandHandler, uint32_t primitiveCount)
+{
+	const vk::Device& vkDevice = device.getDevice();
+
+	asBuildGeometryInfo.type = asType;
+	asBuildGeometryInfo.flags = vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace;
+	asBuildGeometryInfo.mode = vk::BuildAccelerationStructureModeKHR::eBuild;
+	asBuildGeometryInfo.srcAccelerationStructure = nullptr;
+	asBuildGeometryInfo.dstAccelerationStructure = nullptr;
+	asBuildGeometryInfo.geometryCount = 1;
+	asBuildGeometryInfo.pGeometries = &geometry;
+	asBuildGeometryInfo.ppGeometries = nullptr;
+
+	vk::AccelerationStructureBuildSizesInfoKHR asBuildSizesInfo = vkDevice.getAccelerationStructureBuildSizesKHR
+	(
+		vk::AccelerationStructureBuildTypeKHR::eDevice, asBuildGeometryInfo, {primitiveCount}, device.getDLDI()
+	);
+	asBuffer.create(asBuildSizesInfo.accelerationStructureSize);
+
+	vk::AccelerationStructureCreateInfoKHR asCreateInfo{};
+	asCreateInfo.createFlags = vk::AccelerationStructureCreateFlagsKHR();
+	asCreateInfo.buffer = asBuffer.getBuffer();
+	asCreateInfo.offset = 0;
+	asCreateInfo.size = asBuildSizesInfo.accelerationStructureSize;
+	asCreateInfo.type = asType;
+	asCreateInfo.deviceAddress = 0;
+
+	vk::Result result =
+		vkDevice.createAccelerationStructureKHR(&asCreateInfo, nullptr, &accelerationStructure, device.getDLDI());
+	if(result != vk::Result::eSuccess)
+		LOG_ERROR
+		(
+			"Failed to create %s level acceleration structure. Vulkan result: %d",
+			asType == vk::AccelerationStructureTypeKHR::eBottomLevel ? "bottom" : "top",
+			result
+		);
+
+	ScratchAccelerationStructure scratch{device, asBuildSizesInfo.buildScratchSize, asType};
+
+	asBuildGeometryInfo.dstAccelerationStructure = accelerationStructure;
+	asBuildGeometryInfo.scratchData.deviceAddress = scratch.getBufferAddress();
+
+	buildAS(commandHandler, primitiveCount);
+}
+
+// Builds the acceleration structure in the GPU
+void mtd::AccelerationStructure::buildAS(const CommandHandler& commandHandler, uint32_t primitiveCount) const
+{
+	vk::AccelerationStructureBuildRangeInfoKHR buildRangeInfo{};
+	buildRangeInfo.primitiveCount = primitiveCount;
+	const vk::AccelerationStructureBuildRangeInfoKHR* pBuildRangeInfo = &buildRangeInfo;
+
+	vk::CommandBuffer commandBuffer = commandHandler.beginSingleTimeCommand();
+	commandBuffer.buildAccelerationStructuresKHR
+	(
+		1, &asBuildGeometryInfo, &pBuildRangeInfo, device.getDLDI()
+	);
+	commandHandler.endSingleTimeCommand(commandBuffer);
+}

--- a/Engine/src/Vulkan/AccelerationStructure/AccelerationStructure.hpp
+++ b/Engine/src/Vulkan/AccelerationStructure/AccelerationStructure.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../Device/GpuBuffer.hpp"
+
+namespace mtd
+{
+	// Manages Vulkan KHR acceleration structures
+	class AccelerationStructure
+	{
+		public:
+			AccelerationStructure(const Device& device);
+			~AccelerationStructure();
+
+			AccelerationStructure(const AccelerationStructure&) = delete;
+			AccelerationStructure& operator=(const AccelerationStructure&) = delete;
+
+			// Getters
+			const vk::AccelerationStructureKHR& getAccelerationStructure() const { return accelerationStructure; }
+			const GpuBuffer& getBuffer() const { return asBuffer; }
+
+			// Setter
+			void setScratchBufferAddress(vk::DeviceAddress scratchBufferAddress)
+				{ asBuildGeometryInfo.scratchData.deviceAddress = scratchBufferAddress; }
+
+			// Creates the Bottom Level Acceleration Structure (BLAS)
+			void createBLAS
+			(
+				const CommandHandler& commandHandler,
+				vk::DeviceAddress vertexBufferAddress,
+				uint32_t vertexCount,
+				vk::DeviceAddress indexBufferAddress,
+				uint32_t triangleCount
+			);
+			// Creates the Top Level Acceleration Structure (TLAS)
+			void createTLAS(const CommandHandler& commandHandler, vk::DeviceAddress instanceBufferAddress);
+			// Creates an instance buffer from BLAS
+			GpuBuffer createInstanceBuffer() const;
+
+		private:
+			// Vulkan acceleration structure handle
+			vk::AccelerationStructureKHR accelerationStructure;
+			// GPU buffer for the acceleration structure
+			GpuBuffer asBuffer;
+
+			// Acceleration structure data
+			vk::AccelerationStructureTypeKHR asType;
+			vk::AccelerationStructureGeometryKHR geometry;
+			vk::AccelerationStructureBuildGeometryInfoKHR asBuildGeometryInfo;
+
+			// Device reference
+			const Device& device;
+
+			// Handles the common creation logic for both BLAS and TLAS
+			void createAS(const CommandHandler& commandHandler, uint32_t primitiveCount);
+			// Builds the acceleration structure in the GPU
+			void buildAS(const CommandHandler& commandHandler, uint32_t primitiveCount) const;
+	};
+}

--- a/Engine/src/Vulkan/AccelerationStructure/ScratchAccelerationStructure.cpp
+++ b/Engine/src/Vulkan/AccelerationStructure/ScratchAccelerationStructure.cpp
@@ -1,0 +1,37 @@
+#include <pch.hpp>
+#include "ScratchAccelerationStructure.hpp"
+
+#include "../../Utils/Logger.hpp"
+
+mtd::ScratchAccelerationStructure::ScratchAccelerationStructure
+(
+	const Device& device, vk::DeviceSize buildScratchSize, vk::AccelerationStructureTypeKHR asType
+) : device{device},
+	accelerationStructure{nullptr},
+	asBuffer
+	{
+		device,
+		buildScratchSize,
+		vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress
+		| vk::BufferUsageFlagBits::eStorageBuffer,
+		vk::MemoryPropertyFlagBits::eDeviceLocal
+	}
+{
+	vk::AccelerationStructureCreateInfoKHR asScratchCreateInfo{};
+	asScratchCreateInfo.createFlags = vk::AccelerationStructureCreateFlagsKHR();
+	asScratchCreateInfo.buffer = asBuffer.getBuffer();
+	asScratchCreateInfo.offset = 0;
+	asScratchCreateInfo.size = buildScratchSize;
+	asScratchCreateInfo.type = asType;
+	asScratchCreateInfo.deviceAddress = 0;
+
+	vk::Result result = device.getDevice()
+		.createAccelerationStructureKHR(&asScratchCreateInfo, nullptr, &accelerationStructure, device.getDLDI());
+	if(result != vk::Result::eSuccess)
+		LOG_ERROR("Failed to create scratch acceleration structure. Vulkan result: %d", result);
+}
+
+mtd::ScratchAccelerationStructure::~ScratchAccelerationStructure()
+{
+	device.getDevice().destroyAccelerationStructureKHR(accelerationStructure, nullptr, device.getDLDI());
+}

--- a/Engine/src/Vulkan/AccelerationStructure/ScratchAccelerationStructure.hpp
+++ b/Engine/src/Vulkan/AccelerationStructure/ScratchAccelerationStructure.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../Device/GpuBuffer.hpp"
+
+namespace mtd
+{
+	// Handles scratch acceleration structures
+	class ScratchAccelerationStructure
+	{
+		public:
+			ScratchAccelerationStructure
+			(
+				const Device& device, vk::DeviceSize buildScratchSize, vk::AccelerationStructureTypeKHR asType
+			);
+			~ScratchAccelerationStructure();
+
+			ScratchAccelerationStructure(const ScratchAccelerationStructure&) = delete;
+			ScratchAccelerationStructure& operator=(const ScratchAccelerationStructure&) = delete;
+
+			// Getter
+			vk::DeviceAddress getBufferAddress() const { return asBuffer.getBufferAddress(); }
+
+		private:
+			// Vulkan acceleration structure handle
+			vk::AccelerationStructureKHR accelerationStructure;
+			// GPU buffer for the acceleration structure
+			GpuBuffer asBuffer;
+
+			// Device reference
+			const Device& device;
+	};
+}

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.cpp
@@ -108,7 +108,7 @@ void mtd::DescriptorSetHandler::createImagesDescriptorResources
 // Assigns an external GPU buffer as a descriptor
 void mtd::DescriptorSetHandler::assignExternalResourcesToDescriptor
 (
-	uint32_t swappableSetIndex, uint32_t binding, const GpuBuffer& buffer
+	uint32_t swappableSetIndex, uint32_t binding, const GpuBuffer& buffer, const void* pNext
 )
 {
 	assert
@@ -122,6 +122,8 @@ void mtd::DescriptorSetHandler::assignExternalResourcesToDescriptor
 	descriptorBufferInfo.buffer = buffer.getBuffer();
 	descriptorBufferInfo.offset = 0UL;
 	descriptorBufferInfo.range = buffer.getSize();
+
+	resourcesList[swappableSetIndex][binding].pNext = pNext;
 }
 
 // Updates the descriptor set write data
@@ -161,6 +163,7 @@ void mtd::DescriptorSetHandler::writeDescriptorSet(uint32_t swappableSetIndex)
 		writeOps[binding].pImageInfo = pImageInfo;
 		writeOps[binding].pBufferInfo = pBufferInfo;
 		writeOps[binding].pTexelBufferView = nullptr;
+		writeOps[binding].pNext = bindingResources.pNext;
 	}
 
 	device.updateDescriptorSets(static_cast<uint32_t>(writeOps.size()), writeOps.data(), 0, nullptr);

--- a/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.hpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorSetHandler.hpp
@@ -10,6 +10,7 @@ namespace mtd
 		std::unique_ptr<GpuBuffer> descriptorBuffer;
 		vk::DescriptorBufferInfo descriptorBufferInfo;
 		std::vector<vk::DescriptorImageInfo> descriptorImagesInfo;
+		const void* pNext = nullptr;
 	};
 
 	// Handles the data to be sent to the GPU through descriptors
@@ -67,7 +68,7 @@ namespace mtd
 			// Assigns an external GPU buffer as a descriptor
 			void assignExternalResourcesToDescriptor
 			(
-				uint32_t swappableSetIndex, uint32_t binding, const GpuBuffer& buffer
+				uint32_t swappableSetIndex, uint32_t binding, const GpuBuffer& buffer, const void* pNext = nullptr
 			);
 
 			// Updates the descriptor set write data

--- a/Engine/src/Vulkan/Device/GpuBuffer.cpp
+++ b/Engine/src/Vulkan/Device/GpuBuffer.cpp
@@ -5,8 +5,7 @@
 
 mtd::GpuBuffer::GpuBuffer(const Device& device, vk::BufferUsageFlags usage, vk::MemoryPropertyFlags memoryProperties)
 	: device{device}, size{0}, usage{usage}, memoryProperties{memoryProperties}, buffer{nullptr}, bufferMemory{nullptr}
-{
-}
+{}
 
 mtd::GpuBuffer::GpuBuffer
 (
@@ -53,6 +52,14 @@ mtd::GpuBuffer::GpuBuffer(GpuBuffer&& other) noexcept
 {
 	other.buffer = nullptr;
 	other.bufferMemory = nullptr;
+}
+
+vk::DeviceAddress mtd::GpuBuffer::getBufferAddress() const
+{
+	assert(bufferMemory != nullptr && size != 0 && "Invalid buffer address.");
+
+	vk::BufferDeviceAddressInfo addressInfo{buffer};
+	return device.getDevice().getBufferAddress(addressInfo);
 }
 
 // Initializes the buffer

--- a/Engine/src/Vulkan/Device/GpuBuffer.cpp
+++ b/Engine/src/Vulkan/Device/GpuBuffer.cpp
@@ -121,12 +121,15 @@ void mtd::GpuBuffer::resizeBuffer(const CommandHandler& commandHandler, vk::Devi
 }
 
 // Copies data to the buffer
-void mtd::GpuBuffer::copyMemoryToBuffer(vk::DeviceSize copySize, const void* srcData)
+void mtd::GpuBuffer::copyMemoryToBuffer(vk::DeviceSize copySize, const void* srcData, vk::DeviceSize bufferOffset)
 {
-	if(copySize > size)
-		copySize = size;
+	if(copySize > size - bufferOffset)
+	{
+		copySize = size - bufferOffset;
+		LOG_WARNING("Copy size exceeded the available GPU buffer size.");
+	}
 
-	void* memoryLocation = device.getDevice().mapMemory(bufferMemory, 0, copySize);
+	void* memoryLocation = device.getDevice().mapMemory(bufferMemory, bufferOffset, copySize);
 	memcpy(memoryLocation, srcData, copySize);
 	device.getDevice().unmapMemory(bufferMemory);
 }

--- a/Engine/src/Vulkan/Device/GpuBuffer.hpp
+++ b/Engine/src/Vulkan/Device/GpuBuffer.hpp
@@ -27,6 +27,7 @@ namespace mtd
 			const vk::Buffer& getBuffer() const { return buffer; }
 			const vk::DeviceMemory& getBufferMemory() const { return bufferMemory; }
 			vk::DeviceSize getSize() const { return size; }
+			vk::DeviceAddress getBufferAddress() const;
 
 			// Initializes the buffer
 			void create(vk::DeviceSize dataSize);

--- a/Engine/src/Vulkan/Device/GpuBuffer.hpp
+++ b/Engine/src/Vulkan/Device/GpuBuffer.hpp
@@ -37,7 +37,7 @@ namespace mtd
 			void resizeBuffer(const CommandHandler& commandHandler, vk::DeviceSize newSize);
 
 			// Copies data to the buffer
-			void copyMemoryToBuffer(vk::DeviceSize copySize, const void* srcData);
+			void copyMemoryToBuffer(vk::DeviceSize copySize, const void* srcData, vk::DeviceSize bufferOffset = 0);
 
 		private:
 			// Vulkan buffer handles

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
@@ -1,15 +1,33 @@
 #include <pch.hpp>
 #include "RayTracingMeshManager.hpp"
 
+#include "../../../Utils/Logger.hpp"
+
 mtd::RayTracingMeshManager::RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo)
 	: BaseMeshManager{device},
 	currentIndexOffset{0},
 	currentMaterialIndexOffset{0},
+	accelerationStructure{nullptr},
+	accelerationStructureWriteOp{},
+	accelerationStructureBuffer
+	{
+		device,
+		1024,
+		vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+		vk::MemoryPropertyFlagBits::eDeviceLocal
+	},
 	vertexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
 	indexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
 	materialIndexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
 	materialLump{device, materialInfo}
-{}
+{
+	createAccelerationStructure();
+}
+
+mtd::RayTracingMeshManager::~RayTracingMeshManager()
+{
+	device.getDevice().destroyAccelerationStructureKHR(accelerationStructure, nullptr, device.getDLDI());
+}
 
 // Loads the materials and groups the meshes into a lump, then passes the data to the GPU
 void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptorSetHandler)
@@ -21,12 +39,14 @@ void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptor
 	}
 	loadMeshesToGPU(commandHandler);
 
-	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 1, vertexBuffer);
-	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 2, indexBuffer);
-	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 3, materialIndexBuffer);
-	materialLump.assignFloatDataBufferToDescriptor(meshDescriptorSetHandler, 0, 4);
-	if(meshDescriptorSetHandler.getBindingCount() == 6)
-		materialLump.assignTexturesToDescriptor(meshDescriptorSetHandler, 0, 5);
+	meshDescriptorSetHandler
+		.assignExternalResourcesToDescriptor(0, 0, accelerationStructureBuffer, &accelerationStructureWriteOp);
+	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 2, vertexBuffer);
+	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 3, indexBuffer);
+	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 4, materialIndexBuffer);
+	materialLump.assignFloatDataBufferToDescriptor(meshDescriptorSetHandler, 0, 5);
+	if(meshDescriptorSetHandler.getBindingCount() == 7)
+		materialLump.assignTexturesToDescriptor(meshDescriptorSetHandler, 0, 6);
 }
 
 // Creates a new ray tracing mesh
@@ -47,6 +67,26 @@ void mtd::RayTracingMeshManager::rayTraceMesh
 ) const
 {
 	rayTracingPipeline.traceRays(commandBuffer, dldi);
+}
+
+// Creates the acceleration structure
+void mtd::RayTracingMeshManager::createAccelerationStructure()
+{
+	vk::AccelerationStructureCreateInfoKHR asCreateInfo{};
+	asCreateInfo.createFlags = vk::AccelerationStructureCreateFlagsKHR();
+	asCreateInfo.buffer = accelerationStructureBuffer.getBuffer();
+	asCreateInfo.offset = 0;
+	asCreateInfo.size = accelerationStructureBuffer.getSize();
+	asCreateInfo.type = vk::AccelerationStructureTypeKHR::eTopLevel;
+	asCreateInfo.deviceAddress = 0;
+
+	vk::Result result = device.getDevice()
+		.createAccelerationStructureKHR(&asCreateInfo, nullptr, &accelerationStructure, device.getDLDI());
+	if(result != vk::Result::eSuccess)
+		LOG_ERROR("Failed to create acceleration structure. Vulkan result: %d", result);
+
+	accelerationStructureWriteOp.accelerationStructureCount = 1;
+	accelerationStructureWriteOp.pAccelerationStructures = &accelerationStructure;
 }
 
 // Stores a mesh in the lump of data

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.cpp
@@ -5,29 +5,30 @@
 
 mtd::RayTracingMeshManager::RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo)
 	: BaseMeshManager{device},
-	currentIndexOffset{0},
-	currentMaterialIndexOffset{0},
-	accelerationStructure{nullptr},
 	accelerationStructureWriteOp{},
-	accelerationStructureBuffer
+	vertexBuffer
 	{
 		device,
-		1024,
-		vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+		vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress |
+			vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
 		vk::MemoryPropertyFlagBits::eDeviceLocal
 	},
-	vertexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
-	indexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
+	indexBuffer
+	{
+		device,
+		vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress |
+			vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR,
+		vk::MemoryPropertyFlagBits::eDeviceLocal
+	},
+	blas{device},
+	tlas{device},
 	materialIndexBuffer{device, vk::BufferUsageFlagBits::eStorageBuffer, vk::MemoryPropertyFlagBits::eDeviceLocal},
-	materialLump{device, materialInfo}
-{
-	createAccelerationStructure();
-}
-
-mtd::RayTracingMeshManager::~RayTracingMeshManager()
-{
-	device.getDevice().destroyAccelerationStructureKHR(accelerationStructure, nullptr, device.getDLDI());
-}
+	materialLump{device, materialInfo},
+	vertexCount{0},
+	triangleCount{0},
+	currentIndexOffset{0},
+	currentMaterialIndexOffset{0}
+{}
 
 // Loads the materials and groups the meshes into a lump, then passes the data to the GPU
 void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptorSetHandler)
@@ -39,8 +40,10 @@ void mtd::RayTracingMeshManager::loadMeshes(DescriptorSetHandler& meshDescriptor
 	}
 	loadMeshesToGPU(commandHandler);
 
+	createAccelerationStructure();
+
 	meshDescriptorSetHandler
-		.assignExternalResourcesToDescriptor(0, 0, accelerationStructureBuffer, &accelerationStructureWriteOp);
+		.assignExternalResourcesToDescriptor(0, 0, tlas.getBuffer(), &accelerationStructureWriteOp);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 2, vertexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 3, indexBuffer);
 	meshDescriptorSetHandler.assignExternalResourcesToDescriptor(0, 4, materialIndexBuffer);
@@ -72,21 +75,17 @@ void mtd::RayTracingMeshManager::rayTraceMesh
 // Creates the acceleration structure
 void mtd::RayTracingMeshManager::createAccelerationStructure()
 {
-	vk::AccelerationStructureCreateInfoKHR asCreateInfo{};
-	asCreateInfo.createFlags = vk::AccelerationStructureCreateFlagsKHR();
-	asCreateInfo.buffer = accelerationStructureBuffer.getBuffer();
-	asCreateInfo.offset = 0;
-	asCreateInfo.size = accelerationStructureBuffer.getSize();
-	asCreateInfo.type = vk::AccelerationStructureTypeKHR::eTopLevel;
-	asCreateInfo.deviceAddress = 0;
+	blas.createBLAS
+	(
+		commandHandler, vertexBuffer.getBufferAddress(), vertexCount, indexBuffer.getBufferAddress(), triangleCount
+	);
 
-	vk::Result result = device.getDevice()
-		.createAccelerationStructureKHR(&asCreateInfo, nullptr, &accelerationStructure, device.getDLDI());
-	if(result != vk::Result::eSuccess)
-		LOG_ERROR("Failed to create acceleration structure. Vulkan result: %d", result);
+	GpuBuffer instanceBuffer = blas.createInstanceBuffer();
 
-	accelerationStructureWriteOp.accelerationStructureCount = 1;
-	accelerationStructureWriteOp.pAccelerationStructures = &accelerationStructure;
+	tlas.createTLAS(commandHandler, instanceBuffer.getBufferAddress());
+
+	accelerationStructureWriteOp.accelerationStructureCount = 1U;
+	accelerationStructureWriteOp.pAccelerationStructures = &tlas.getAccelerationStructure();
 }
 
 // Stores a mesh in the lump of data
@@ -124,6 +123,9 @@ void mtd::RayTracingMeshManager::loadMeshesToGPU(const CommandHandler& traceRays
 
 	for(RayTracingMesh& mesh: meshes)
 		mesh.createInstanceBuffer();
+
+	vertexCount = vertexLump.size();
+	triangleCount = indexLump.size() / 3;
 
 	vertexLump.clear();
 	indexLump.clear();

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
@@ -3,14 +3,16 @@
 #include "RayTracingMesh.hpp"
 #include "../BaseMeshManager.hpp"
 #include "../../Pipeline/RayTracingPipeline.hpp"
+#include "../../AccelerationStructure/AccelerationStructure.hpp"
 
 namespace mtd
 {
+	// Handles data from all ray tracing meshes
 	class RayTracingMeshManager : public BaseMeshManager<RayTracingMesh>
 	{
 		public:
 			RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo);
-			~RayTracingMeshManager();
+			~RayTracingMeshManager() = default;
 
 			// Getters
 			virtual uint32_t getMaterialCount() const override { return materialLump.getMaterialCount(); }
@@ -47,10 +49,10 @@ namespace mtd
 			) const;
 
 		private:
-			// Acceleration structure
-			vk::AccelerationStructureKHR accelerationStructure;
+			// Acceleration structures
+			AccelerationStructure blas;
+			AccelerationStructure tlas;
 			vk::WriteDescriptorSetAccelerationStructureKHR accelerationStructureWriteOp;
-			GpuBuffer accelerationStructureBuffer;
 
 			// Vertex and index data of all meshes in the VRAM
 			GpuBuffer vertexBuffer;
@@ -65,6 +67,10 @@ namespace mtd
 
 			// Mesh manager materials
 			MaterialLump materialLump;
+
+			// Resource counters
+			uint32_t vertexCount;
+			uint32_t triangleCount;
 
 			// Index offset counters
 			uint32_t currentIndexOffset;

--- a/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
+++ b/Engine/src/Vulkan/Mesh/RayTracingMesh/RayTracingMeshManager.hpp
@@ -10,7 +10,7 @@ namespace mtd
 	{
 		public:
 			RayTracingMeshManager(const Device& device, const MaterialInfo& materialInfo);
-			~RayTracingMeshManager() = default;
+			~RayTracingMeshManager();
 
 			// Getters
 			virtual uint32_t getMaterialCount() const override { return materialLump.getMaterialCount(); }
@@ -47,6 +47,11 @@ namespace mtd
 			) const;
 
 		private:
+			// Acceleration structure
+			vk::AccelerationStructureKHR accelerationStructure;
+			vk::WriteDescriptorSetAccelerationStructureKHR accelerationStructureWriteOp;
+			GpuBuffer accelerationStructureBuffer;
+
 			// Vertex and index data of all meshes in the VRAM
 			GpuBuffer vertexBuffer;
 			GpuBuffer indexBuffer;
@@ -64,6 +69,9 @@ namespace mtd
 			// Index offset counters
 			uint32_t currentIndexOffset;
 			uint32_t currentMaterialIndexOffset;
+
+			// Creates the acceleration structure
+			void createAccelerationStructure();
 
 			// Stores a mesh in the lump of data
 			void loadMeshToLump(RayTracingMesh& mesh);

--- a/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
+++ b/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
@@ -19,8 +19,7 @@ mtd::RayTracingPipeline::RayTracingPipeline
 	sbtBuffer
 	{
 		mtdDevice,
-		vk::BufferUsageFlagBits::eShaderBindingTableKHR |
-			vk::BufferUsageFlagBits::eShaderDeviceAddress |
+		vk::BufferUsageFlagBits::eShaderBindingTableKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress |
 			vk::BufferUsageFlagBits::eTransferDst,
 		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
 	}
@@ -80,7 +79,7 @@ void mtd::RayTracingPipeline::traceRays
 		missRegionSBT,
 		hitRegionSBT,
 		callableRegionSBT,
-		info.width, info.height, 1,
+		info.width, info.height, 2,
 		dldi
 	);
 
@@ -94,7 +93,7 @@ void mtd::RayTracingPipeline::configurePipelineDescriptorSet()
 	image.defineDescriptorImageInfo(&descriptorImageInfo);
 	descriptorImageInfo.imageLayout = vk::ImageLayout::eGeneral;
 
-	descriptorSetHandlers[0].createImageDescriptorResources(0, 0, descriptorImageInfo);
+	descriptorSetHandlers[0].createImageDescriptorResources(0, 1, descriptorImageInfo);
 	descriptorSetHandlers[0].writeDescriptorSet(0);
 }
 
@@ -137,9 +136,10 @@ void mtd::RayTracingPipeline::resize(const Device& mtdDevice, vk::Extent2D swapc
 // Loads the pipeline shader modules
 void mtd::RayTracingPipeline::loadShaderModules()
 {
-	shaders.reserve(2);
+	shaders.reserve(3);
 	shaders.emplace_back(device, vk::ShaderStageFlagBits::eRaygenKHR, info.rayGenShaderPath.c_str());
 	shaders.emplace_back(device, vk::ShaderStageFlagBits::eMissKHR, info.missShaderPath.c_str());
+	shaders.emplace_back(device, vk::ShaderStageFlagBits::eClosestHitKHR, info.closestHitShaderPath.c_str());
 }
 
 // Configures the descriptor set handlers to be used
@@ -147,23 +147,30 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 {
 	descriptorSetHandlers.reserve(info.descriptorSetInfo.size() == 0 ? 1 : 2);
 
-	const uint32_t bindingCount = info.materialTextureTypes.empty() ? 5U : 6U;
+	const uint32_t bindingCount = info.materialTextureTypes.empty() ? 6U : 7U;
 	uint32_t bindingIndex = 0U;
 	std::vector<vk::DescriptorSetLayoutBinding> layoutBindings(bindingCount);
+
+	layoutBindings[bindingIndex].binding = bindingIndex;
+	layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eAccelerationStructureKHR;
+	layoutBindings[bindingIndex].descriptorCount = 1U;
+	layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
+	layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
+	bindingIndex++;
+
 	layoutBindings[bindingIndex].binding = bindingIndex;
 	layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eStorageImage;
 	layoutBindings[bindingIndex].descriptorCount = 1U;
-	layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eMissKHR;
+	layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
 	layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
-
 	bindingIndex++;
 
-	while(bindingIndex < 5U)
+	while(bindingIndex < 6U)
 	{
 		layoutBindings[bindingIndex].binding = bindingIndex;
 		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eStorageBuffer;
 		layoutBindings[bindingIndex].descriptorCount = 1U;
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
+		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eMissKHR;
 		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
 
 		bindingIndex++;
@@ -171,16 +178,16 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 
 	vk::DescriptorSetLayoutBindingFlagsCreateInfo descriptorSetLayoutBindingsCreateInfo{};
 	const vk::DescriptorSetLayoutBindingFlagsCreateInfo* pDescriptorSetLayoutBindingsCreateInfo = nullptr;
-	std::array<vk::DescriptorBindingFlags, 6> bindingFlags;
+	std::array<vk::DescriptorBindingFlags, 7> bindingFlags;
 	if(!info.materialTextureTypes.empty())
 	{
 		layoutBindings[bindingIndex].binding = bindingIndex;
 		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eCombinedImageSampler;
 		layoutBindings[bindingIndex].descriptorCount = MAX_TEXTURE_COUNT;
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
+		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eMissKHR;
 		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
 
-		bindingFlags[5] = vk::DescriptorBindingFlagBits::eVariableDescriptorCount |
+		bindingFlags.back() = vk::DescriptorBindingFlagBits::eVariableDescriptorCount |
 			vk::DescriptorBindingFlagBits::ePartiallyBound;
 		
 		descriptorSetLayoutBindingsCreateInfo.bindingCount = bindingCount;
@@ -286,17 +293,21 @@ void mtd::RayTracingPipeline::createShaderBindingTable(const Device& mtdDevice)
 {
 	const vk::PhysicalDeviceRayTracingPipelinePropertiesKHR& rayTracingProperties =
 		mtdDevice.fetchRayTracingProperties();
-	const uint32_t shaderGroupHandleSize =
-		(rayTracingProperties.shaderGroupHandleSize + rayTracingProperties.shaderGroupBaseAlignment - 1) &
-		~(rayTracingProperties.shaderGroupBaseAlignment - 1);
-	const vk::DeviceSize sbtSize = shaders.size() * shaderGroupHandleSize;
 
-	sbtBuffer.create(sbtSize);
+	const uint32_t handleSize = rayTracingProperties.shaderGroupHandleSize;
+	const uint32_t handleAlignment = rayTracingProperties.shaderGroupHandleAlignment;
+	const uint32_t baseAlignment = rayTracingProperties.shaderGroupBaseAlignment;
 
-	std::vector<uint8_t> shaderHandleStorage(sbtSize);
+	const uint32_t handleSizeAligned = (handleSize + handleAlignment - 1) & ~(handleAlignment - 1);
+	const uint32_t baseSizeAligned = (handleSize + baseAlignment - 1) & ~(baseAlignment - 1);
+	
+	std::vector<uint8_t> shaderHandleStorage(shaders.size() * handleSize);
 	vk::Result result = device.getRayTracingShaderGroupHandlesKHR
 	(
-		pipeline, 0U, static_cast<uint32_t>(shaders.size()), sbtSize, shaderHandleStorage.data(), mtdDevice.getDLDI()
+		pipeline,
+		0U, static_cast<uint32_t>(shaders.size()),
+		shaderHandleStorage.size(), shaderHandleStorage.data(),
+		mtdDevice.getDLDI()
 	);
 	if(result != vk::Result::eSuccess)
 	{
@@ -304,18 +315,38 @@ void mtd::RayTracingPipeline::createShaderBindingTable(const Device& mtdDevice)
 		return;
 	}
 
-	sbtBuffer.copyMemoryToBuffer(sbtSize, shaderHandleStorage.data());
+	const vk::DeviceSize sbtSize = shaders.size() * baseSizeAligned;
+	sbtBuffer.create(sbtSize);
 
 	vk::BufferDeviceAddressInfo bufferAddressInfo{sbtBuffer.getBuffer()};
 	vk::DeviceAddress sbtAddress = device.getBufferAddress(bufferAddressInfo);
 
 	rayGenRegionSBT.deviceAddress = sbtAddress;
-	rayGenRegionSBT.stride = shaderGroupHandleSize;
-	rayGenRegionSBT.size = shaderGroupHandleSize;
+	rayGenRegionSBT.stride = baseSizeAligned;
+	rayGenRegionSBT.size = baseSizeAligned;
 
-	missRegionSBT.deviceAddress = sbtAddress + static_cast<vk::DeviceSize>(shaderGroupHandleSize);
-	missRegionSBT.stride = shaderGroupHandleSize;
-	missRegionSBT.size = shaderGroupHandleSize;
+	missRegionSBT.deviceAddress = sbtAddress + rayGenRegionSBT.size;
+	missRegionSBT.stride = handleSizeAligned;
+	missRegionSBT.size = baseSizeAligned;
+
+	hitRegionSBT.deviceAddress = sbtAddress + rayGenRegionSBT.size + missRegionSBT.size;
+	hitRegionSBT.stride = handleSizeAligned;
+	hitRegionSBT.size = baseSizeAligned;
+
+	uint8_t* pShaderHandleStorage = shaderHandleStorage.data();
+	vk::DeviceSize bufferOffset = 0;
+
+	sbtBuffer.copyMemoryToBuffer(handleSize, pShaderHandleStorage, bufferOffset);
+	pShaderHandleStorage += handleSize;
+	bufferOffset += rayGenRegionSBT.size;
+
+	sbtBuffer.copyMemoryToBuffer(handleSize, pShaderHandleStorage, bufferOffset);
+	pShaderHandleStorage += handleSize;
+	bufferOffset += missRegionSBT.size;
+
+	sbtBuffer.copyMemoryToBuffer(handleSize, pShaderHandleStorage, bufferOffset);
+	pShaderHandleStorage += handleSize;
+	bufferOffset += hitRegionSBT.size;
 }
 
 // Defines the shader groups
@@ -324,7 +355,7 @@ void mtd::RayTracingPipeline::defineShaderGroups
 	std::vector<vk::RayTracingShaderGroupCreateInfoKHR>& shaderGroupCreateInfos
 ) const
 {
-	shaderGroupCreateInfos.resize(2);
+	shaderGroupCreateInfos.resize(3);
 	shaderGroupCreateInfos[0].type = vk::RayTracingShaderGroupTypeKHR::eGeneral;
 	shaderGroupCreateInfos[0].generalShader = 0;
 	shaderGroupCreateInfos[0].closestHitShader = vk::ShaderUnusedKHR;
@@ -338,4 +369,11 @@ void mtd::RayTracingPipeline::defineShaderGroups
 	shaderGroupCreateInfos[1].anyHitShader = vk::ShaderUnusedKHR;
 	shaderGroupCreateInfos[1].intersectionShader = vk::ShaderUnusedKHR;
 	shaderGroupCreateInfos[1].pShaderGroupCaptureReplayHandle = nullptr;
+
+	shaderGroupCreateInfos[2].type = vk::RayTracingShaderGroupTypeKHR::eTrianglesHitGroup;
+	shaderGroupCreateInfos[2].generalShader = vk::ShaderUnusedKHR;
+	shaderGroupCreateInfos[2].closestHitShader = 2;
+	shaderGroupCreateInfos[2].anyHitShader = vk::ShaderUnusedKHR;
+	shaderGroupCreateInfos[2].intersectionShader = vk::ShaderUnusedKHR;
+	shaderGroupCreateInfos[2].pShaderGroupCaptureReplayHandle = nullptr;
 }

--- a/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
+++ b/Engine/src/Vulkan/Pipeline/RayTracingPipeline.cpp
@@ -22,7 +22,8 @@ mtd::RayTracingPipeline::RayTracingPipeline
 		vk::BufferUsageFlagBits::eShaderBindingTableKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress |
 			vk::BufferUsageFlagBits::eTransferDst,
 		vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
-	}
+	},
+	shaderRenderingInfo{4U, 8U, 0U, 0U}
 {
 	loadShaderModules();
 	createDescriptorSetLayouts();
@@ -73,6 +74,14 @@ void mtd::RayTracingPipeline::traceRays
 		);
 	}
 
+	shaderRenderingInfo.randomSeed = rand();
+	commandBuffer.pushConstants
+	(
+		pipelineLayout,
+		vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR,
+		0, sizeof(RayTracingRenderData), &shaderRenderingInfo
+	);
+
 	commandBuffer.traceRaysKHR
 	(
 		rayGenRegionSBT,
@@ -84,6 +93,8 @@ void mtd::RayTracingPipeline::traceRays
 	);
 
 	image.transitionImageLayout(commandBuffer, vk::ImageLayout::eShaderReadOnlyOptimal);
+
+	shaderRenderingInfo.accumulatedFrames++;
 }
 
 // Configures the render target image descriptor
@@ -131,6 +142,8 @@ void mtd::RayTracingPipeline::resize(const Device& mtdDevice, vk::Extent2D swapc
 		vk::ImageViewType::e2D
 	);
 	configurePipelineDescriptorSet();
+
+	resetAccumulation();
 }
 
 // Loads the pipeline shader modules
@@ -154,7 +167,8 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 	layoutBindings[bindingIndex].binding = bindingIndex;
 	layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eAccelerationStructureKHR;
 	layoutBindings[bindingIndex].descriptorCount = 1U;
-	layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eRaygenKHR;
+	layoutBindings[bindingIndex].stageFlags =
+		vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR;
 	layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
 	bindingIndex++;
 
@@ -170,7 +184,7 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 		layoutBindings[bindingIndex].binding = bindingIndex;
 		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eStorageBuffer;
 		layoutBindings[bindingIndex].descriptorCount = 1U;
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eMissKHR;
+		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eClosestHitKHR;
 		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
 
 		bindingIndex++;
@@ -184,7 +198,7 @@ void mtd::RayTracingPipeline::createDescriptorSetLayouts()
 		layoutBindings[bindingIndex].binding = bindingIndex;
 		layoutBindings[bindingIndex].descriptorType = vk::DescriptorType::eCombinedImageSampler;
 		layoutBindings[bindingIndex].descriptorCount = MAX_TEXTURE_COUNT;
-		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eMissKHR;
+		layoutBindings[bindingIndex].stageFlags = vk::ShaderStageFlagBits::eClosestHitKHR;
 		layoutBindings[bindingIndex].pImmutableSamplers = nullptr;
 
 		bindingFlags.back() = vk::DescriptorBindingFlagBits::eVariableDescriptorCount |
@@ -237,12 +251,17 @@ void mtd::RayTracingPipeline::createPipelineLayout(const vk::DescriptorSetLayout
 	for(const DescriptorSetHandler& descriptorSetHandler: descriptorSetHandlers)
 		descriptorSetLayouts.push_back(descriptorSetHandler.getLayout());
 
+	vk::PushConstantRange pushConstantRange{};
+	pushConstantRange.stageFlags = vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR;
+	pushConstantRange.offset = 0;
+	pushConstantRange.size = sizeof(RayTracingRenderData);
+
 	vk::PipelineLayoutCreateInfo pipelineLayoutCreateInfo{};
 	pipelineLayoutCreateInfo.flags = vk::PipelineLayoutCreateFlags();
 	pipelineLayoutCreateInfo.setLayoutCount = static_cast<uint32_t>(descriptorSetLayouts.size());
 	pipelineLayoutCreateInfo.pSetLayouts = descriptorSetLayouts.data();
-	pipelineLayoutCreateInfo.pushConstantRangeCount = 0;
-	pipelineLayoutCreateInfo.pPushConstantRanges = nullptr;
+	pipelineLayoutCreateInfo.pushConstantRangeCount = 1;
+	pipelineLayoutCreateInfo.pPushConstantRanges = &pushConstantRange;
 
 	vk::Result result = device.createPipelineLayout(&pipelineLayoutCreateInfo, nullptr, &pipelineLayout);
 	if(result != vk::Result::eSuccess)
@@ -270,7 +289,7 @@ void mtd::RayTracingPipeline::createRayTracingPipeline(const vk::detail::Dispatc
 	pipelineCreateInfo.pStages = shaderStageInfos.data();
 	pipelineCreateInfo.groupCount = static_cast<uint32_t>(shaderGroupCreateInfos.size());
 	pipelineCreateInfo.pGroups = shaderGroupCreateInfos.data();
-	pipelineCreateInfo.maxPipelineRayRecursionDepth = 1;
+	pipelineCreateInfo.maxPipelineRayRecursionDepth = shaderRenderingInfo.maxRecursionDepth;
 	pipelineCreateInfo.pLibraryInfo = nullptr;
 	pipelineCreateInfo.pLibraryInterface = nullptr;
 	pipelineCreateInfo.pDynamicState = nullptr;
@@ -317,9 +336,7 @@ void mtd::RayTracingPipeline::createShaderBindingTable(const Device& mtdDevice)
 
 	const vk::DeviceSize sbtSize = shaders.size() * baseSizeAligned;
 	sbtBuffer.create(sbtSize);
-
-	vk::BufferDeviceAddressInfo bufferAddressInfo{sbtBuffer.getBuffer()};
-	vk::DeviceAddress sbtAddress = device.getBufferAddress(bufferAddressInfo);
+	vk::DeviceAddress sbtAddress = sbtBuffer.getBufferAddress();
 
 	rayGenRegionSBT.deviceAddress = sbtAddress;
 	rayGenRegionSBT.stride = baseSizeAligned;

--- a/Engine/src/Vulkan/Pipeline/RayTracingPipeline.hpp
+++ b/Engine/src/Vulkan/Pipeline/RayTracingPipeline.hpp
@@ -20,6 +20,9 @@ namespace mtd
 
 			RayTracingPipeline(RayTracingPipeline&& other) noexcept;
 
+			// Setters
+			void setSamplesPerPixel(uint32_t spp) const { shaderRenderingInfo.samplesPerPixel = spp; }
+
 			// Binds the pipeline and performs the ray tracing
 			void traceRays
 			(
@@ -38,6 +41,9 @@ namespace mtd
 			// Resizes the render target image if needed
 			void resize(const Device& mtdDevice, vk::Extent2D swapchainExtent);
 
+			// Resets the image render target frame accumulation
+			void resetAccumulation() const { shaderRenderingInfo.accumulatedFrames = 0U; }
+
 		private:
 			// Render storage image
 			Image image;
@@ -50,6 +56,9 @@ namespace mtd
 			vk::StridedDeviceAddressRegionKHR missRegionSBT;
 			vk::StridedDeviceAddressRegionKHR hitRegionSBT;
 			vk::StridedDeviceAddressRegionKHR callableRegionSBT;
+
+			// Push constant data for the ray tracing shaders
+			mutable RayTracingRenderData shaderRenderingInfo;
 
 			// Loads the pipeline shader modules
 			void loadShaderModules();

--- a/resources/scenes/ray_tracing.json
+++ b/resources/scenes/ray_tracing.json
@@ -18,6 +18,7 @@
 		{
 			"name": "Ray Tracing Pipeline",
 			"ray-gen-shader": "ray-tracing.rgen.spv",
+			"closest-hit-shader": "ray-tracing.rchit.spv",
 			"miss-shader": "ray-tracing.rmiss.spv",
 			"descriptor-set-info": [],
 			"resolution-ratio-horizontal": 1.0,


### PR DESCRIPTION
A basic acceleration structure system has been implemented to the ray tracing pipeline, allowing the usage of a closest hit shader module.

A simple path tracing algorithm has been implemented with this setup to render a basic scene with diffuse material.