### PR TITLE
Fix Ray Tracing initialization on Intel Arc GPUs

### DIFF
--- a/Engine/src/Scene/Scene.cpp
+++ b/Engine/src/Scene/Scene.cpp
@@ -68,8 +68,9 @@ void mtd::Scene::allocateResources
 	{
 		for(const auto& [type, count]: rtPipeline.getDescriptorTypeCount())
 			totalDescriptorTypeCount[type] += count;
+		totalDescriptorTypeCount[vk::DescriptorType::eAccelerationStructureKHR]++;
 		totalDescriptorTypeCount[vk::DescriptorType::eStorageImage]++;
-		totalDescriptorTypeCount[vk::DescriptorType::eStorageBuffer] += 2;
+		totalDescriptorTypeCount[vk::DescriptorType::eStorageBuffer] += 4;
 	}
 
 	std::vector<PoolSizeData> poolSizesInfo{totalDescriptorTypeCount.size()};

--- a/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
+++ b/Engine/src/Vulkan/Descriptors/DescriptorPool.cpp
@@ -4,7 +4,7 @@
 #include "../../Utils/Logger.hpp"
 
 mtd::DescriptorPool::DescriptorPool(const vk::Device& device)
-	: device{device}, isClear{true}
+	: device{device}, descriptorPool{nullptr}, isClear{true}
 {}
 
 mtd::DescriptorPool::~DescriptorPool()

--- a/Engine/src/Vulkan/Device/Device.cpp
+++ b/Engine/src/Vulkan/Device/Device.cpp
@@ -95,7 +95,7 @@ void mtd::Device::configureQueues(std::vector<vk::DeviceQueueCreateInfo>& device
 	if(queueFamilies.getGraphicsFamilyIndex() != queueFamilies.getPresentFamilyIndex())
 		uniqueQueueFamilyIndices.push_back(queueFamilies.getPresentFamilyIndex());
 
-	float queuePriority = 1.0f;
+	static constexpr float queuePriority = 1.0f;
 	for(uint32_t uniqueQueueFamilyIndex: uniqueQueueFamilyIndices)
 	{
 		deviceQueueCreateInfos.emplace_back


### PR DESCRIPTION
On Intel Arc GPUs, a more careful configuration of the Vulkan descriptor pool is required to ensure a proper resource allocation for ray tracing features.